### PR TITLE
add null checks in json deserialization

### DIFF
--- a/src/main/java/gov/nist/csd/pm/pap/serialization/json/JSONGraph.java
+++ b/src/main/java/gov/nist/csd/pm/pap/serialization/json/JSONGraph.java
@@ -1,5 +1,6 @@
 package gov.nist.csd.pm.pap.serialization.json;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -22,6 +23,14 @@ public class JSONGraph {
         this.oas = oas;
         this.users = users;
         this.objects = objects;
+    }
+
+    public JSONGraph() {
+        this.pcs = new ArrayList<>();
+        this.uas = new ArrayList<>();
+        this.oas = new ArrayList<>();
+        this.users = new ArrayList<>();
+        this.objects = new ArrayList<>();
     }
 
     public List<JSONNode> getPcs() {

--- a/src/test/java/gov/nist/csd/pm/pap/serialization/JSONSerializationTest.java
+++ b/src/test/java/gov/nist/csd/pm/pap/serialization/JSONSerializationTest.java
@@ -1,0 +1,44 @@
+package gov.nist.csd.pm.pap.serialization;
+
+import gov.nist.csd.pm.impl.memory.pap.MemoryPAP;
+import gov.nist.csd.pm.pap.exception.PMException;
+import gov.nist.csd.pm.pap.graph.relationship.AccessRightSet;
+import gov.nist.csd.pm.pap.query.UserContext;
+import gov.nist.csd.pm.pap.serialization.json.JSONDeserializer;
+import gov.nist.csd.pm.pap.serialization.json.JSONGraph;
+import gov.nist.csd.pm.pap.serialization.json.JSONPolicy;
+import gov.nist.csd.pm.pap.serialization.json.JSONSerializer;
+import gov.nist.csd.pm.util.SamplePolicy;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+public class JSONSerializationTest {
+
+    @Test
+    void testJSONSerializationDoesNotThrowNPE() throws PMException, IOException {
+        List<JSONPolicy> policies = List.of(
+                new JSONPolicy(new AccessRightSet(), new JSONGraph(), List.of(), List.of(), List.of(), List.of()),
+                new JSONPolicy(null, new JSONGraph(), List.of(), List.of(), List.of(), List.of()),
+                new JSONPolicy(new AccessRightSet(), null, List.of(), List.of(), List.of(), List.of()),
+                new JSONPolicy(new AccessRightSet(), new JSONGraph(), null, List.of(), List.of(), List.of()),
+                new JSONPolicy(new AccessRightSet(), new JSONGraph(), List.of(), null, List.of(), List.of()),
+                new JSONPolicy(new AccessRightSet(), new JSONGraph(), List.of(), List.of(), null, List.of()),
+                new JSONPolicy(new AccessRightSet(), new JSONGraph(), List.of(), List.of(), List.of(), null),
+                new JSONPolicy(new AccessRightSet(), new JSONGraph(List.of(), List.of(), List.of(), List.of(), List.of()), List.of(), List.of(), List.of(), List.of()),
+                new JSONPolicy(new AccessRightSet(), new JSONGraph(null, List.of(), List.of(), List.of(), List.of()), List.of(), List.of(), List.of(), List.of()),
+                new JSONPolicy(new AccessRightSet(), new JSONGraph(List.of(), null, List.of(), List.of(), List.of()), List.of(), List.of(), List.of(), List.of()),
+                new JSONPolicy(new AccessRightSet(), new JSONGraph(List.of(), List.of(), null, List.of(), List.of()), List.of(), List.of(), List.of(), List.of()),
+                new JSONPolicy(new AccessRightSet(), new JSONGraph(List.of(), List.of(), List.of(), null, List.of()), List.of(), List.of(), List.of(), List.of()),
+                new JSONPolicy(new AccessRightSet(), new JSONGraph(List.of(), List.of(), List.of(), List.of(), null), List.of(), List.of(), List.of(), List.of())
+        );
+
+        for (JSONPolicy policy : policies) {
+            assertDoesNotThrow(() -> new MemoryPAP().deserialize(new UserContext(), policy.toString(), new JSONDeserializer()));
+        }
+    }
+
+}


### PR DESCRIPTION
Fixes an issue where JSONDeserializer could produce a NPE if any of the policy entities were null in the provided json.