### PR TITLE
Fix pml scope and assignment bugs

### DIFF
--- a/src/main/java/gov/nist/csd/pm/pap/GraphModifier.java
+++ b/src/main/java/gov/nist/csd/pm/pap/GraphModifier.java
@@ -87,22 +87,22 @@ public class GraphModifier extends Modifier implements GraphModification {
 
     @Override
     public void assign(String ascendant, Collection<String> descendants) throws PMException {
-        if(!checkAssignInput(ascendant, descendants)) {
-            return;
-        }
-
         for (String descendant : descendants) {
+            if(!checkAssignInput(ascendant, descendant)) {
+                continue;
+            }
+
             store.graph().createAssignment(ascendant, descendant);
         }
     }
 
     @Override
     public void deassign(String ascendant, Collection<String> descendants) throws PMException {
-        if(!checkDeassignInput(ascendant, descendants)) {
-            return;
-        }
-
         for (String descendant : descendants) {
+            if(!checkDeassignInput(ascendant, descendant)) {
+                continue;
+            }
+
             store.graph().deleteAssignment(ascendant, descendant);
         }
     }
@@ -326,29 +326,27 @@ public class GraphModifier extends Modifier implements GraphModification {
      * @return True if the execution should proceed, false otherwise.
      * @throws PMException If any PM related exceptions occur in the implementing class.
      */
-    protected boolean checkAssignInput(String ascendant, Collection<String> descendants) throws PMException {
-        for (String descendant : descendants) {
-            // getting both nodes will check if they exist
-            if (!store.graph().nodeExists(ascendant)) {
-                throw new NodeDoesNotExistException(ascendant);
-            } else if (!store.graph().nodeExists(descendant)) {
-                throw new NodeDoesNotExistException(descendant);
-            }
-
-            // ignore if assignment already exists
-            if (store.graph().getAdjacentDescendants(ascendant).contains(descendant)) {
-                return false;
-            }
-
-            Node ascNode = store.graph().getNode(ascendant);
-            Node descNode = store.graph().getNode(descendant);
-
-            // check node types make a valid assignment relation
-            Assignment.checkAssignment(ascNode.getType(), descNode.getType());
-
-            // check the assignment won't create a loop
-            checkAssignmentDoesNotCreateLoop(ascendant, descendant);
+    protected boolean checkAssignInput(String ascendant, String descendant) throws PMException {
+        // getting both nodes will check if they exist
+        if (!store.graph().nodeExists(ascendant)) {
+            throw new NodeDoesNotExistException(ascendant);
+        } else if (!store.graph().nodeExists(descendant)) {
+            throw new NodeDoesNotExistException(descendant);
         }
+
+        // ignore if assignment already exists
+        if (store.graph().getAdjacentDescendants(ascendant).contains(descendant)) {
+            return false;
+        }
+
+        Node ascNode = store.graph().getNode(ascendant);
+        Node descNode = store.graph().getNode(descendant);
+
+        // check node types make a valid assignment relation
+        Assignment.checkAssignment(ascNode.getType(), descNode.getType());
+
+        // check the assignment won't create a loop
+        checkAssignmentDoesNotCreateLoop(ascendant, descendant);
 
         return true;
     }
@@ -363,25 +361,23 @@ public class GraphModifier extends Modifier implements GraphModification {
      * @return True if the execution should proceed, false otherwise.
      * @throws PMException If any PM related exceptions occur in the implementing class.
      */
-    protected boolean checkDeassignInput(String ascendant, Collection<String> descendants) throws PMException {
-        for (String descendant : descendants) {
-            if (!store.graph().nodeExists(ascendant)) {
-                throw new NodeDoesNotExistException(ascendant);
-            } else if (!store.graph().nodeExists(descendant)) {
-                throw new NodeDoesNotExistException(descendant);
-            } else if (ascendant.equals(AdminPolicyNode.PM_ADMIN_OBJECT.nodeName()) &&
-                    descendant.equals(AdminPolicyNode.PM_ADMIN_PC.nodeName())) {
-                throw new CannotDeleteAdminPolicyConfigException();
-            }
+    protected boolean checkDeassignInput(String ascendant, String descendant) throws PMException {
+        if (!store.graph().nodeExists(ascendant)) {
+            throw new NodeDoesNotExistException(ascendant);
+        } else if (!store.graph().nodeExists(descendant)) {
+            throw new NodeDoesNotExistException(descendant);
+        } else if (ascendant.equals(AdminPolicyNode.PM_ADMIN_OBJECT.nodeName()) &&
+                descendant.equals(AdminPolicyNode.PM_ADMIN_PC.nodeName())) {
+            throw new CannotDeleteAdminPolicyConfigException();
+        }
 
-            Collection<String> descs = store.graph().getAdjacentDescendants(ascendant);
-            if (!descs.contains(descendant)) {
-                return false;
-            }
+        Collection<String> descs = store.graph().getAdjacentDescendants(ascendant);
+        if (!descs.contains(descendant)) {
+            return false;
+        }
 
-            if (descs.size() == 1) {
-                throw new DisconnectedNodeException(ascendant, descendant);
-            }
+        if (descs.size() == 1) {
+            throw new DisconnectedNodeException(ascendant, descendant);
         }
 
         return true;

--- a/src/main/java/gov/nist/csd/pm/pap/GraphModifier.java
+++ b/src/main/java/gov/nist/csd/pm/pap/GraphModifier.java
@@ -322,7 +322,7 @@ public class GraphModifier extends Modifier implements GraphModification {
      * return false to indicate to the caller that execution should not proceed.
      *
      * @param ascendant  The ascendant node.
-     * @param descendants The descendant nodes.
+     * @param descendant The descendant node.
      * @return True if the execution should proceed, false otherwise.
      * @throws PMException If any PM related exceptions occur in the implementing class.
      */
@@ -357,7 +357,7 @@ public class GraphModifier extends Modifier implements GraphModification {
      * an error will occur.
      *
      * @param ascendant  The ascendant node.
-     * @param descendants The descendant nodes.
+     * @param descendant The descendant node.
      * @return True if the execution should proceed, false otherwise.
      * @throws PMException If any PM related exceptions occur in the implementing class.
      */

--- a/src/main/java/gov/nist/csd/pm/pap/pml/context/ExecutionContext.java
+++ b/src/main/java/gov/nist/csd/pm/pap/pml/context/ExecutionContext.java
@@ -55,6 +55,10 @@ public class ExecutionContext implements Serializable {
         return new ExecutionContext(author, pap, scope.copy());
     }
 
+    public ExecutionContext copyWithoutScope() throws PMException {
+        return new ExecutionContext(author, pap);
+    }
+
     public Value executeStatements(List<PMLStatement> stmts, Map<String, Object> operands) throws PMException {
         ExecutionContext copy = writeOperandsToScope(operands);
 

--- a/src/main/java/gov/nist/csd/pm/pap/pml/expression/FunctionInvokeExpression.java
+++ b/src/main/java/gov/nist/csd/pm/pap/pml/expression/FunctionInvokeExpression.java
@@ -92,7 +92,7 @@ public class FunctionInvokeExpression extends Expression {
     @Override
     public Value execute(ExecutionContext ctx, PAP pap) throws PMException {
         String name = signature.getFunctionName();
-        ExecutionContext funcInvokeCtx = ctx.copy();
+        ExecutionContext funcInvokeCtx = ctx.copyWithoutScope();
         Map<String, Value> operandValues = prepareOperandExpressions(ctx, pap);
 
         // set the execution context if exec is a PML exec

--- a/src/main/java/gov/nist/csd/pm/pdp/PDPExecutionContext.java
+++ b/src/main/java/gov/nist/csd/pm/pdp/PDPExecutionContext.java
@@ -31,6 +31,11 @@ public class PDPExecutionContext extends ExecutionContext {
     }
 
     @Override
+    public ExecutionContext copyWithoutScope() throws PMException {
+        return new PDPExecutionContext(author, pdpTx);
+    }
+
+    @Override
     public Value executeStatements(List<PMLStatement> statements, Map<String, Object> operands) throws PMException {
         ExecutionContext copy = writeOperandsToScope(operands);
 

--- a/src/test/java/gov/nist/csd/pm/pap/modification/GraphModifierTest.java
+++ b/src/test/java/gov/nist/csd/pm/pap/modification/GraphModifierTest.java
@@ -611,6 +611,18 @@ public abstract class GraphModifierTest extends PAPTestInitializer {
             assertTrue(pap.query().graph().isAscendant("ua4", "ua2"));
             assertFalse(pap.query().graph().isAscendant("ua4", "ua3"));
         }
+
+        @Test
+        void testOneDescendantIsAlreadyAssigned() throws PMException {
+            pap.modify().graph().createPolicyClass("pc1");
+            pap.modify().graph().createUserAttribute("ua1", List.of("pc1"));
+            pap.modify().graph().createUserAttribute("ua2", List.of("pc1"));
+
+            pap.modify().graph().assign("ua2", List.of("pc1", "ua1"));
+
+            assertTrue(pap.query().graph().isAscendant("ua2", "pc1"));
+            assertTrue(pap.query().graph().isAscendant("ua2", "ua1"));
+        }
     }
 
     @Nested
@@ -681,6 +693,18 @@ public abstract class GraphModifierTest extends PAPTestInitializer {
             assertTrue(pap.query().graph().isAscendant("ua4", "ua3"));
         }
 
+        @Test
+        void testOneDescendantIsAlreadyDeassigned() throws PMException {
+            pap.modify().graph().createPolicyClass("pc1");
+            pap.modify().graph().createUserAttribute("ua1", List.of("pc1"));
+            pap.modify().graph().createUserAttribute("ua2", List.of("pc1"));
+            pap.modify().graph().createUserAttribute("ua3", List.of("ua1", "ua2"));
+
+            pap.modify().graph().deassign("ua3", List.of("pc1", "ua1"));
+
+            assertFalse(pap.query().graph().getAdjacentDescendants("ua3").contains("pc1"));
+            assertFalse(pap.query().graph().getAdjacentDescendants("ua3").contains("ua1"));
+        }
     }
 
     @Nested

--- a/src/test/java/gov/nist/csd/pm/pap/pml/expression/FunctionInvokeExpressionTest.java
+++ b/src/test/java/gov/nist/csd/pm/pap/pml/expression/FunctionInvokeExpressionTest.java
@@ -240,4 +240,21 @@ class FunctionInvokeExpressionTest {
         pap.executePML(new UserContext(), pml);
         assertFalse(pap.query().graph().nodeExists("pc1"));
     }
+
+    @Test
+    void testScopeIsNotCopiedToFunctionInvokeExpression() throws PMException {
+        String pml = """
+                operation op1() {
+                    x := ""
+                    op2()
+                }
+                
+                operation op2() {
+                    x := ""
+                }
+                
+                op1()
+                """;
+        assertDoesNotThrow(() -> new MemoryPAP().executePML(new UserContext("u1"), pml));
+    }
 }


### PR DESCRIPTION
- Fixes problem with PML scope. When a function was invoked, the scope was being copied to the function leading to variable already exists exceptions when they shouldn't.
- Fixes issue with assign and deassign where if one descendant was skipped, all descendants would be skipped