### PR TITLE
remove create in obligation syntax, allow keywords as ID in index var…

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,8 @@ public class Main {
 
     // create an obligation that associates ua1 with any OA
     String obligationPML = """
-            create obligation "sample_obligation" {
-            	create rule "rule1"
+            obligation "sample_obligation" {
+            	rule "rule1"
             	when any user
             	performs "create_object_attribute"
             	on {
@@ -133,12 +133,12 @@ public class Main {
     associate "ua2" and "ua1" with ["associate"]
 
     create prohibition "deny u1 write on oa1"
-    deny user "u1"
+    deny u "u1"
     access rights ["write"]
     on union of ["oa1"]
 
-    create obligation "sample_obligation" {
-        create rule "rule1"
+    obligation "sample_obligation" {
+        rule "rule1"
         when any user
         performs "create_object_attribute"
         on {
@@ -204,8 +204,8 @@ Obligations should be defined using PML because obligation responses are defined
 
 ```java
 String pml = """
-        create obligation "sample_obligation" {
-            create rule "rule1"
+        obligation "sample_obligation" {
+            rule "rule1"
             when any user
             performs "create_object_attribute"
             on {

--- a/docs/pml.md
+++ b/docs/pml.md
@@ -13,7 +13,7 @@ pap.executePML(new UserContext(userId), pml);
 
 - Any operations and routines will be stored in the policy store.
 - All [admin policy nodes](/src/main/java/gov/nist/csd/pm/core/pap/admin/AdminPolicyNode.java) will be defined as constants during compilation and execution.  
-  `create object attribute "oa1" in [PM_ADMIN_OBJECT] `
+  `create OA "oa1" in [PM_ADMIN_OBJECT] `
 
 ## Basics  
   
@@ -238,7 +238,7 @@ operation op1(a string, b []string, c map[string]string) string {
 Create a policy class node with the given **name**.  
   
 ```  
-'create policy class' name=expression
+'create PC' name=expression
 ```  
 
 - `name` is a **string** expression.  
@@ -248,7 +248,7 @@ Create a policy class node with the given **name**.
 Create a node of type object attribute, user attribute, object, or user and assign it to a set of existing nodes. Types can also be expressed using their short version: pc, ua, oa, u, o.
   
 ```  
-'create' ('object attribute' | 'user attribute' | 'object' | 'user') name=expression   
+'create' ('OA' | 'UA' | 'O' | 'U') name=expression   
 'in' assignTo=expression   
 ```  
 
@@ -327,7 +327,7 @@ Create a new prohibition.
   
 ```  
 'create prohibition' name=expression   
-'deny' ('user' | 'user attribute' | 'process') subject=expression   
+'deny' ('U' | 'UA' | 'process') subject=expression   
 'access rights' accessRights=expression   
 'on' ('intersection'|'union') 'of' containers=expression ;  
 ```  
@@ -343,9 +343,9 @@ Create new obligation. The author of the obligation will be the user that compil
   
 ```  
 createObligationStatement:  
-    'create obligation' name=expression '{' createRuleStatement* '}';  
+    'obligation' name=expression '{' createRuleStatement* '}';  
 createRuleStatement:  
-    'create rule' ruleName=expression  
+    'rule' ruleName=expression  
     'when' subjectPattern  
     'performs' operationPattern  
     ('on' argPattern)?  
@@ -413,7 +413,7 @@ Delete a node, prohibition, or obligation.
   
 ```  
 'delete'  
-('policy class' | 'object attribute' | 'user attribute' | 'object' | 'user' | 'obligation' | 'prohibition') expression  
+('PC' | 'OA' | 'UA' | 'O' | 'U' | 'obligation' | 'prohibition') expression  
 ```  
 
 - `expression` is a **string** expression.  

--- a/src/main/java/gov/nist/csd/pm/core/epp/EPP.java
+++ b/src/main/java/gov/nist/csd/pm/core/epp/EPP.java
@@ -78,7 +78,7 @@ public class EPP implements EventSubscriber {
         Map<String, Object> map = new HashMap<>();
         map.put("user", eventCtx.user().getName());
         map.put("attrs", eventCtx.user().getAttrs());
-        map.put("process", eventCtx.user());
+        map.put("process", eventCtx.user().getProcess());
         map.put("opName", eventCtx.opName());
         map.put("args", eventCtx.args());
 

--- a/src/main/java/gov/nist/csd/pm/core/pap/modification/GraphModifier.java
+++ b/src/main/java/gov/nist/csd/pm/core/pap/modification/GraphModifier.java
@@ -426,8 +426,6 @@ public class GraphModifier extends Modifier implements GraphModification {
             throws PMException {
         long id = idGenerator.generateId(name, type);
 
-
-
         if (name.equals(AdminPolicyNode.PM_ADMIN_POLICY_CLASSES.nodeName())) {
             return AdminPolicyNode.PM_ADMIN_POLICY_CLASSES.nodeId();
         } else if (policyStore.graph().nodeExists(name)) {

--- a/src/main/java/gov/nist/csd/pm/core/pap/pml/antlr4/PMLLexer.g4
+++ b/src/main/java/gov/nist/csd/pm/core/pap/pml/antlr4/PMLLexer.g4
@@ -14,8 +14,9 @@ CREATE      : 'create' ;
 DELETE      : 'delete' ;
 
 // obligation keywords
-POLICY_ELEMENT: 'policy element' | 'pe' ;
-CONTAINED: 'contained';
+POLICY_ELEMENT: 'policy element' | PE ;
+PE: 'pe' ;
+CONTAINED: 'contained' ;
 RULE: 'rule' ;
 WHEN: 'when' ;
 PERFORMS: 'performs' ;
@@ -46,16 +47,14 @@ PROHIBITION: 'prohibition';
 OBLIGATION: 'obligation';
 ACCESS_RIGHTS: 'access rights' ;
 
+PC : PC_FRAG ;
+OA : OA_FRAG ;
+UA : UA_FRAG ;
+U: U_FRAG;
+O: O_FRAG;
+
 NODE: 'node' ;
-POLICY_CLASS: 'policy class' | 'pc' | 'PC' ;
-OBJECT_ATTRIBUTE: 'object attribute' | 'oa' | 'OA' ;
-USER_ATTRIBUTE: 'user attribute' | 'ua' | 'UA' ;
-USER_ATTRIBUTES: 'user attributes' | 'uas' | 'UAs' ;
-OBJECT_ATTRIBUTES: 'object attributes' | 'oas' | 'OAs' ;
-OBJECT: 'object' | 'o' | 'O' ;
-USER: 'user' | 'u' | 'U' ;
-ATTRIBUTE:  'attribute';
-ASSOCIATIONS: 'associations' ;
+USER: 'user' ;
 
 // Keywords
 
@@ -129,6 +128,16 @@ WS:                 [ \t\r\n\u000C]+ -> channel(HIDDEN);
 COMMENT:            '/*' .*? '*/'    -> channel(HIDDEN);
 LINE_COMMENT:       '//' ~[\r\n]*    -> channel(HIDDEN);
 
+fragment P   : [pP] ;
+fragment C   : [cC] ;
+fragment PC_FRAG : P C ;
+
+fragment O_FRAG   : [oO] ;
+fragment A   : [aA] ;
+fragment OA_FRAG : O_FRAG A ;
+
+fragment U_FRAG   : [uU] ;
+fragment UA_FRAG : U_FRAG A ;
 
 fragment EscapeSequence
     : '\\' [btnfr"'\\]

--- a/src/main/java/gov/nist/csd/pm/core/pap/pml/antlr4/PMLParser.g4
+++ b/src/main/java/gov/nist/csd/pm/core/pap/pml/antlr4/PMLParser.g4
@@ -45,18 +45,18 @@ operationStatement: (
 
 statementBlock: OPEN_CURLY statement* CLOSE_CURLY ;
 
-createPolicyStatement: CREATE POLICY_CLASS name=expression;
+createPolicyStatement: CREATE PC name=expression;
 
 createNonPCStatement:
     CREATE nonPCNodeType name=expression
     IN in=expression ;
 nonPCNodeType:
-    (OBJECT_ATTRIBUTE | USER_ATTRIBUTE | OBJECT | USER) ;
+    (OA | UA | O | U) ;
 
 createObligationStatement:
-    CREATE OBLIGATION expression OPEN_CURLY createRuleStatement* CLOSE_CURLY;
+    OBLIGATION expression OPEN_CURLY createRuleStatement* CLOSE_CURLY;
 createRuleStatement:
-    CREATE RULE ruleName=expression
+    RULE ruleName=expression
     WHEN subjectPattern
     PERFORMS operationPattern
     (ON argPattern)?
@@ -112,7 +112,7 @@ responseStatement:
 
 createProhibitionStatement:
     CREATE PROHIBITION name=expression
-    DENY (USER | USER_ATTRIBUTE | PROCESS) subject=expression
+    DENY (U | UA | PROCESS) subject=expression
     ACCESS_RIGHTS accessRights=expression
     ON (INTERSECTION|UNION) OF containers=expression ;
 
@@ -229,8 +229,66 @@ variableReference: ID (index)* ;
 
 index:
     OPEN_BRACKET key=expression CLOSE_BRACKET #BracketIndex
-    | DOT key=id #DotIndex;
-id: ID;
+    | DOT key=idIndex #DotIndex;
 
 functionInvoke: ID functionInvokeArgs ;
 functionInvokeArgs: OPEN_PAREN expressionList? CLOSE_PAREN ;
+
+idIndex:
+    ID
+    | OPERATION
+    | CHECK
+    | ROUTINE
+    | FUNCTION
+    | CREATE
+    | DELETE
+    | PE
+    | CONTAINED
+    | RULE
+    | WHEN
+    | PERFORMS
+    | AS
+    | ON
+    | IN
+    | DO
+    | ANY
+    | INTERSECTION
+    | UNION
+    | PROCESS
+    | ASSIGN
+    | DEASSIGN
+    | FROM
+    | OF
+    | TO
+    | ASSOCIATE
+    | AND
+    | WITH
+    | DISSOCIATE
+    | DENY
+    | PROHIBITION
+    | OBLIGATION
+    | NODE
+    | PC
+    | OA
+    | UA
+    | O
+    | U
+    | BREAK
+    | DEFAULT
+    | MAP
+    | ELSE
+    | CONST
+    | IF
+    | RANGE
+    | CONTINUE
+    | FOREACH
+    | RETURN
+    | VAR
+    | STRING_TYPE
+    | BOOL_TYPE
+    | VOID_TYPE
+    | ARRAY_TYPE
+    | NIL_LIT
+    | TRUE
+    | FALSE
+    ;

--- a/src/main/java/gov/nist/csd/pm/core/pap/pml/compiler/visitor/CreateNonPCStmtVisitor.java
+++ b/src/main/java/gov/nist/csd/pm/core/pap/pml/compiler/visitor/CreateNonPCStmtVisitor.java
@@ -29,11 +29,11 @@ public class CreateNonPCStmtVisitor extends PMLBaseVisitor<CreateNonPCStatement>
     }
 
     private NodeType getNodeType(PMLParser.NonPCNodeTypeContext nodeType) {
-        if (nodeType.OBJECT_ATTRIBUTE() != null) {
+        if (nodeType.OA() != null) {
             return OA;
-        } else if (nodeType.USER_ATTRIBUTE() != null) {
+        } else if (nodeType.UA() != null) {
             return NodeType.UA;
-        } else if (nodeType.OBJECT() != null) {
+        } else if (nodeType.O() != null) {
             return NodeType.O;
         } else {
             return NodeType.U;

--- a/src/main/java/gov/nist/csd/pm/core/pap/pml/compiler/visitor/CreateProhibitionStmtVisitor.java
+++ b/src/main/java/gov/nist/csd/pm/core/pap/pml/compiler/visitor/CreateProhibitionStmtVisitor.java
@@ -26,9 +26,9 @@ public class CreateProhibitionStmtVisitor extends PMLBaseVisitor<CreateProhibiti
         Expression<String> name = ExpressionVisitor.compile(visitorCtx, ctx.name, STRING_TYPE);
         Expression<String> subject = ExpressionVisitor.compile(visitorCtx, ctx.subject, STRING_TYPE);
         ProhibitionSubjectType type = ProhibitionSubjectType.PROCESS;
-        if (ctx.USER() != null) {
+        if (ctx.U() != null) {
             type = ProhibitionSubjectType.USER;
-        } else if (ctx.USER_ATTRIBUTE() != null) {
+        } else if (ctx.UA() != null) {
             type = ProhibitionSubjectType.USER_ATTRIBUTE;
         }
 

--- a/src/main/java/gov/nist/csd/pm/core/pap/pml/statement/operation/CreateObligationStatement.java
+++ b/src/main/java/gov/nist/csd/pm/core/pap/pml/statement/operation/CreateObligationStatement.java
@@ -37,7 +37,7 @@ public class CreateObligationStatement extends OperationStatement<ObligationOpAr
     public ObligationOpArgs prepareArgs(ExecutionContext ctx, PAP pap) throws PMException {
         String nameStr = name.execute(ctx, pap);
 
-        // execute the create rule statements and add to obligation
+        // execute the rule statements and add to obligation
         List<Rule> rules = new ArrayList<>();
         for (CreateRuleStatement createRuleStmt : ruleStmts) {
             Rule rule = createRuleStmt.execute(ctx, pap);
@@ -71,7 +71,7 @@ public class CreateObligationStatement extends OperationStatement<ObligationOpAr
         String indent = indent(indentLevel);
         return String.format(
             """
-            %screate obligation %s {
+            %sobligation %s {
             %s%s}""", indent, name, sb, indent);
     }
 

--- a/src/main/java/gov/nist/csd/pm/core/pap/pml/statement/operation/CreateRuleStatement.java
+++ b/src/main/java/gov/nist/csd/pm/core/pap/pml/statement/operation/CreateRuleStatement.java
@@ -114,7 +114,7 @@ public class CreateRuleStatement extends PMLStatement<Rule> {
 
         return String.format(
             """
-            %screate rule %s
+            %srule %s
             %swhen %s
             %sperforms %s
             %s

--- a/src/test/java/gov/nist/csd/pm/core/epp/EPPTest.java
+++ b/src/test/java/gov/nist/csd/pm/core/epp/EPPTest.java
@@ -58,8 +58,8 @@ class EPPTest {
                 
                 }
                 
-                create obligation "obl1" {
-                    create rule "op1"
+                obligation "obl1" {
+                    rule "op1"
                     when any user
                     performs "op1"
                     on {
@@ -74,7 +74,7 @@ class EPPTest {
                         }
                     }
                 
-                    create rule "op2"
+                    rule "op2"
                     when any user
                     performs "op2"
                     on {
@@ -164,8 +164,8 @@ class EPPTest {
                 associate "ua1" and "oa1" with ["read"]
                 associate "ua1" and PM_ADMIN_POLICY_CLASSES with ["*a"]
                 
-                create obligation "obl1" {
-                    create rule "op1"
+                obligation "obl1" {
+                    rule "op1"
                     when any user
                     performs "read"
                     on {
@@ -198,15 +198,15 @@ class EPPTest {
                 create u "u1" in ["ua1"]
                 associate "ua1" and "oa1" with ["*"]
                 associate "ua1" and PM_ADMIN_POLICY_CLASSES with ["*"]
-                create obligation "test" {
-                    create rule "rule1"
+                obligation "test" {
+                    rule "rule1"
                     when any user
                     performs "create_object_attribute"
                     on {
                         descendants: "oa1"
                     }
                     do(evtCtx) {
-                        create policy class "pc2"
+                        create PC "pc2"
                     }
                 }
                 """;
@@ -237,8 +237,8 @@ class EPPTest {
                 associate "ua1" and "oa1" with ["*a"]
                 associate "ua1" and PM_ADMIN_BASE_OA with ["*a"]
                 
-                create obligation "test" {
-                    create rule "rule1"
+                obligation "test" {
+                    rule "rule1"
                     when any user
                     performs "create_object_attribute"
                     on {
@@ -246,14 +246,14 @@ class EPPTest {
                     }
                     do(ctx) {
                         name := ctx.opName
-                        create policy class name
+                        create PC name
 
                         name = ctx.args.name
-                        create policy class name + "_test"
+                        create PC name + "_test"
                         set properties of name + "_test" to {"key": name}
 
                         userCtx := ctx["user"]
-                        create policy class ctx["user"] + "_test"
+                        create PC ctx["user"] + "_test"
                     }
                 }
                 """;
@@ -364,8 +364,8 @@ class EPPTest {
                 associate "ua1" and "oa1" with ["*a"]
                 associate "ua1" and PM_ADMIN_POLICY_CLASSES with ["create_policy_class"]
                 
-                create obligation "test" {
-                    create rule "rule1"
+                obligation "test" {
+                    rule "rule1"
                     when any user
                     performs "create_object_attribute"
                     on {
@@ -404,8 +404,8 @@ class EPPTest {
                 associate "ua1" and "oa1" with ["*a"]
                 associate "ua1" and PM_ADMIN_POLICY_CLASSES with ["create_policy_class"]
                 
-                create obligation "test" {
-                    create rule "rule1"
+                obligation "test" {
+                    rule "rule1"
                     when any user
                     performs "create_object_attribute"
                     on {
@@ -416,7 +416,7 @@ class EPPTest {
                             return
                         }
                 
-                        create policy class "test"
+                        create PC "test"
                     }
                 }
                 """;
@@ -448,8 +448,8 @@ class EPPTest {
                     create o "o1" in ["oa1"]
                 }
                 
-                create obligation "obl1" {
-                    create rule "rule1"
+                obligation "obl1" {
+                    rule "rule1"
                     when any user
                     performs "create_policy_class"
                     do(ctx) {

--- a/src/test/java/gov/nist/csd/pm/core/example/Main.java
+++ b/src/test/java/gov/nist/csd/pm/core/example/Main.java
@@ -42,8 +42,8 @@ public class Main {
 
         // create an obligation that associates ua1 with any OA
         String obligationPML = """
-				create obligation "sample_obligation" {
-					create rule "rule1"
+				obligation "sample_obligation" {
+					rule "rule1"
 					when any user
 					performs "create_object_attribute"
 					on {
@@ -74,12 +74,12 @@ public class Main {
 		associate "ua2" and "ua1" with ["associate"]
 
 		create prohibition "deny u1 write on oa1"
-		deny user "u1"
+		deny u "u1"
 		access rights ["write"]
 		on union of ["oa1"]
 
-		create obligation "sample_obligation" {
-		    create rule "rule1"
+		obligation "sample_obligation" {
+		    rule "rule1"
 		    when any user
 		    performs "create_object_attribute"
 		    on {

--- a/src/test/java/gov/nist/csd/pm/core/pap/PAPTest.java
+++ b/src/test/java/gov/nist/csd/pm/core/pap/PAPTest.java
@@ -163,8 +163,8 @@ public abstract class PAPTest extends PAPTestInitializer {
                 create ua "ua1" in ["pc1"]
                 create ua "ua2" in ["pc1"]
                 
-                create obligation "o1" {
-                    create rule "r1"
+                obligation "o1" {
+                    rule "r1"
                     when any user 
                     performs any operation
                     do(ctx) {}

--- a/src/test/java/gov/nist/csd/pm/core/pap/modification/ObligationsModifierTest.java
+++ b/src/test/java/gov/nist/csd/pm/core/pap/modification/ObligationsModifierTest.java
@@ -204,15 +204,15 @@ public abstract class ObligationsModifierTest extends PAPTestInitializer {
             loadSamplePolicyFromPML(pap);
 
             pap.runTx(tx -> pap.executePML(new UserContext(id("u1")), """
-                create obligation "ob1" {
-                    create rule "r1"
+                obligation "ob1" {
+                    rule "r1"
                     when any user
                     performs any operation
                     do(ctx) { }
                 }
                 
-                create obligation "ob2" {
-                    create rule "r1"
+                obligation "ob2" {
+                    rule "r1"
                     when any user
                     performs any operation
                     do(ctx) { }
@@ -220,15 +220,15 @@ public abstract class ObligationsModifierTest extends PAPTestInitializer {
                 """));
             assertThrows(PMException.class, () -> pap.runTx(tx -> {
                 pap.executePML(new UserContext(id("u1")), """
-                    create obligation "ob3" {
-                        create rule "r1"
+                    obligation "ob3" {
+                        rule "r1"
                         when any user
                         performs any operation
                         do(ctx) { }
                     }
                     
-                    create obligation "ob4" {
-                        create rule "r1"
+                    obligation "ob4" {
+                        rule "r1"
                         when any user
                         performs any operation
                         do(ctx) { }
@@ -251,8 +251,8 @@ public abstract class ObligationsModifierTest extends PAPTestInitializer {
             loadSamplePolicyFromPML(pap);
 
             pap.executePML(new UserContext(id("u1")), """
-                    create obligation "ob1" {
-                        create rule "r1"
+                    obligation "ob1" {
+                        rule "r1"
                         when any user
                         performs any operation
                         do(ctx) { }
@@ -269,15 +269,15 @@ public abstract class ObligationsModifierTest extends PAPTestInitializer {
             loadSamplePolicyFromPML(pap);
 
             pap.runTx(tx -> pap.executePML(new UserContext(id("u1")), """
-                create obligation "ob1" {
-                    create rule "r1"
+                obligation "ob1" {
+                    rule "r1"
                     when any user 
                     performs any operation
                     do(ctx) { }
                 }
                 
-                create obligation "ob2" {
-                    create rule "r1"
+                obligation "ob2" {
+                    rule "r1"
                     when any user 
                     performs any operation
                     do(ctx) { }

--- a/src/test/java/gov/nist/csd/pm/core/pap/modification/ProhibitionsModifierTest.java
+++ b/src/test/java/gov/nist/csd/pm/core/pap/modification/ProhibitionsModifierTest.java
@@ -101,12 +101,12 @@ public abstract class ProhibitionsModifierTest extends PAPTestInitializer {
             pap.runTx(tx -> {
                 tx.executePML(new UserContext(id("u1")), """
                     create prohibition "p1"
-                    deny user attribute "ua1"
+                    deny ua "ua1"
                     access rights ["read"]
                     on union of {"US project": false}
                     
                     create prohibition "p2"
-                    deny user attribute "ua1"
+                    deny ua "ua1"
                     access rights ["read"]
                     on union of {"US project": false}
                     """);
@@ -115,12 +115,12 @@ public abstract class ProhibitionsModifierTest extends PAPTestInitializer {
             assertThrows(PMException.class, () -> pap.runTx(tx -> {
                 tx.executePML(new UserContext(id("u1")), """
                     create prohibition "p3"
-                    deny user attribute "ua1"
+                    deny ua "ua1"
                     access rights ["read"]
                     on union of {"US project": false}
                     
                     create prohibition "p4"
-                    deny user attribute "ua1"
+                    deny ua "ua1"
                     access rights ["read"]
                     on union of {"US project": false}
                     """);
@@ -173,12 +173,12 @@ public abstract class ProhibitionsModifierTest extends PAPTestInitializer {
             pap.runTx(tx -> {
                 tx.executePML(new UserContext(id("u1")), """
                     create prohibition "p1"
-                    deny user attribute "ua1"
+                    deny ua "ua1"
                     access rights ["read"]
                     on union of {"US project": false}
                     
                     create prohibition "p2"
-                    deny user attribute "ua1"
+                    deny ua "ua1"
                     access rights ["read"]
                     on union of {"US project": false}
                     """);

--- a/src/test/java/gov/nist/csd/pm/core/pap/pml/ExecutionTest.java
+++ b/src/test/java/gov/nist/csd/pm/core/pap/pml/ExecutionTest.java
@@ -25,23 +25,23 @@ public class ExecutionTest {
                 """
                 set resource operations ["read", "write"]
                 
-                create policy class "pc1"
+                create PC "pc1"
                 
                 set properties of "pc1" to {"k": "v"}
                 
-                create object attribute "oa1" in ["pc1"]
-                create object attribute "oa2" in ["pc1"]
-                create object attribute "oa3" in ["pc1"]
+                create OA "oa1" in ["pc1"]
+                create OA "oa2" in ["pc1"]
+                create OA "oa3" in ["pc1"]
                 
                 var descendants = ["oa1", "oa2", "oa3"]
-                create object "o1" in descendants
+                create O "o1" in descendants
                 
-                create user attribute "ua1" in ["pc1"]
-                create user attribute "ua2" in ["pc1"]
-                create user attribute "ua3" in ["pc1"]
+                create UA "ua1" in ["pc1"]
+                create UA "ua2" in ["pc1"]
+                create UA "ua3" in ["pc1"]
                 
                 var username = "u1"
-                create user username in ["ua1"]
+                create U username in ["ua1"]
                 assign username to ["ua2", "ua3"]
                 
                 associate "ua1" and "oa1" with ["read", "write"]
@@ -158,7 +158,7 @@ public class ExecutionTest {
                 var x = "test"
                 var y = "test"
                 if x == y {
-                    create policy class "pc1"
+                    create PC "pc1"
                 }
                 """;
         pap.executePML(new TestUserContext("u1"), input);
@@ -169,9 +169,9 @@ public class ExecutionTest {
                 var y = "test"
                 var z = "test1"
                 if x == z {
-                    create policy class "pc1"
+                    create PC "pc1"
                 } else if x == y {
-                    create policy class "pc2"
+                    create PC "pc2"
                 }
                 """;
         pap = new TestPAP();
@@ -185,11 +185,11 @@ public class ExecutionTest {
                 var y = "test1"
                 var z = "test2"
                 if x == z {
-                    create policy class "pc1"
+                    create PC "pc1"
                 } else if x == y {
-                    create policy class "pc2"
+                    create PC "pc2"
                 } else {
-                    create policy class "pc3"
+                    create PC "pc3"
                 }
                 """;
         pap = new TestPAP();
@@ -205,9 +205,9 @@ public class ExecutionTest {
                 var y = "test1"
                 var z = "test2"
                 if x == y {
-                    create policy class "pc1"
+                    create PC "pc1"
                 } else {
-                    create policy class "pc2"
+                    create PC "pc2"
                 }
                 """;
         pap = new TestPAP();
@@ -222,9 +222,9 @@ public class ExecutionTest {
                 var y = "test1"
                 var z = "test2"
                 if x != y {
-                    create policy class "pc1"
+                    create PC "pc1"
                 } else {
-                    create policy class "pc2"
+                    create PC "pc2"
                 }
                 """;
         pap = new TestPAP();
@@ -241,7 +241,7 @@ public class ExecutionTest {
         
         String input = """
                 foreach x in ["pc1", "pc2", "pc3"] {
-                    create policy class x
+                    create PC x
                 }
                 """;
         pap.executePML(new TestUserContext("u1"), input);
@@ -253,7 +253,7 @@ public class ExecutionTest {
         input = """
                 var m = {"k1": "pc1", "k2": "pc2", "k3": "pc3"}
                 foreach x, y in m {
-                    create policy class y
+                    create PC y
                 }
                 """;
         pap = new TestPAP();
@@ -267,7 +267,7 @@ public class ExecutionTest {
         input = """
                 foreach x, y in {"k1": ["pc1", "pc2"], "k2": ["pc3"]} {
                     foreach z in y {
-                        create policy class z
+                        create PC z
                     }
                 }
                 """;
@@ -282,7 +282,7 @@ public class ExecutionTest {
         input = """
                 foreach x, y in {"k1": ["pc1", "pc2"], "k2": ["pc3"]} {
                     foreach z in y {
-                        create policy class z
+                        create PC z
                         break
                     }
                 }
@@ -299,7 +299,7 @@ public class ExecutionTest {
                 foreach x, y in {"k1": ["pc1", "pc2"], "k2": ["pc3"]} {
                     foreach z in y {
                         continue
-                        create policy class z
+                        create PC z
                     }
                 }
                 """;
@@ -320,7 +320,7 @@ public class ExecutionTest {
                         continue
                     }
                     
-                    create policy class x
+                    create PC x
                 }
                 """;
         pap = new TestPAP();
@@ -336,7 +336,7 @@ public class ExecutionTest {
     void testFunction() throws PMException {
         String input = """
                 operation testFunc(any x) {
-                    create policy class x
+                    create PC x
                 }
                 
                 testFunc("pc1")
@@ -364,7 +364,7 @@ public class ExecutionTest {
         String input2 = """
                 x := "hello"
                 operation testFunc() {
-                    create policy class x + " world"
+                    create PC x + " world"
                 }
                 
                 testFunc()
@@ -383,7 +383,7 @@ public class ExecutionTest {
         String input = """
                 var m = {"k1": {"k1-1": {"k1-1-1": "v1"}}}
                 var x = m["k1"]["k1-1"]["k1-1-1"]
-                create policy class x
+                create PC x
                 """;
          PAP pap = new TestPAP();
         
@@ -428,12 +428,12 @@ public class ExecutionTest {
 
         String input = """
                 create prohibition "p1"
-                deny user attribute "ua1"
+                deny ua "ua1"
                 access rights ["read"]
                 on union of {"oa1": false}
                 
                 create prohibition "p2"
-                deny user attribute "ua1"
+                deny ua "ua1"
                 access rights ["read"]
                 on union of {"oa1": false}
                 """;
@@ -453,7 +453,7 @@ public class ExecutionTest {
                     return s
                 }
                 
-                create policy class testFunc("test")
+                create PC testFunc("test")
                 """;
 
          PAP pap = new TestPAP();
@@ -470,7 +470,7 @@ public class ExecutionTest {
                     return s
                 }
                 
-                create policy class testFunc("test")
+                create PC testFunc("test")
                 """;
 
          PAP pap = new TestPAP();

--- a/src/test/java/gov/nist/csd/pm/core/pap/pml/PMLBasicFunctionsTest.java
+++ b/src/test/java/gov/nist/csd/pm/core/pap/pml/PMLBasicFunctionsTest.java
@@ -33,8 +33,8 @@ public class PMLBasicFunctionsTest {
                     create pc name
                 }
                 
-                create obligation "ob1" {
-                    create rule "r1"
+                obligation "ob1" {
+                    rule "r1"
                     when any user
                     performs any operation
                     do(ctx) {
@@ -75,8 +75,8 @@ public class PMLBasicFunctionsTest {
                     }
                 }
                 
-                create obligation "ob1" {
-                    create rule "r1"
+                obligation "ob1" {
+                    rule "r1"
                     when any user
                     performs any operation
                     do(ctx) {
@@ -118,8 +118,8 @@ public class PMLBasicFunctionsTest {
                     create pc "pc2"
                 }
                 
-                create obligation "ob1" {
-                    create rule "r1"
+                obligation "ob1" {
+                    rule "r1"
                     when any user
                     performs "op1"
                     do(ctx) {
@@ -157,8 +157,8 @@ public class PMLBasicFunctionsTest {
                     create pc "pc2"
                 }
                 
-                create obligation "ob1" {
-                    create rule "r1"
+                obligation "ob1" {
+                    rule "r1"
                     when any user
                     performs any operation
                     do(ctx) {

--- a/src/test/java/gov/nist/csd/pm/core/pap/pml/PMLTest.java
+++ b/src/test/java/gov/nist/csd/pm/core/pap/pml/PMLTest.java
@@ -42,7 +42,7 @@ public class PMLTest {
                 associate "ua1" and PM_ADMIN_BASE_OA with ["assign"]
                 
                 create prohibition "pro1"
-                deny user "u2"
+                deny u "u2"
                 access rights ["assign"]
                 on union of {PM_ADMIN_BASE_OA: false}
                 """);
@@ -137,7 +137,7 @@ public class PMLTest {
                 associate "ua1" and PM_ADMIN_BASE_OA with ["assign"]
                 
                 create prohibition "pro1"
-                deny user "u2"
+                deny u "u2"
                 access rights ["assign"]
                 on union of {PM_ADMIN_BASE_OA: false}
                 

--- a/src/test/java/gov/nist/csd/pm/core/pap/pml/compiler/visitor/CreateNonPCStmtVisitorTest.java
+++ b/src/test/java/gov/nist/csd/pm/core/pap/pml/compiler/visitor/CreateNonPCStmtVisitorTest.java
@@ -29,7 +29,7 @@ class CreateNonPCStmtVisitorTest {
     void testSuccess() {
         PMLParser.StatementContext ctx = TestPMLParser.parseStatement(
                 """
-                create user attribute "ua1" in ["a"]
+                create UA "ua1" in ["a"]
                 """);
         VisitorContext visitorCtx = new VisitorContext(testGlobalScope);
         PMLStatement stmt = new CreateNonPCStmtVisitor(visitorCtx).visit(ctx);
@@ -45,14 +45,14 @@ class CreateNonPCStmtVisitorTest {
         VisitorContext visitorCtx = new VisitorContext(testGlobalScope);
         testCompilationError(
                 """
-                create user attribute ["ua1"] in ["a"]
+                create UA ["ua1"] in ["a"]
                 """, visitorCtx, 1,
                 "expected expression type string, got []string"
         );
 
         testCompilationError(
                 """
-                create user attribute "ua1" in "a"
+                create UA "ua1" in "a"
                 """, visitorCtx, 1,
                 "expected expression type []string, got string"
         );

--- a/src/test/java/gov/nist/csd/pm/core/pap/pml/compiler/visitor/CreateObligationStmtVisitorTest.java
+++ b/src/test/java/gov/nist/csd/pm/core/pap/pml/compiler/visitor/CreateObligationStmtVisitorTest.java
@@ -21,7 +21,7 @@ class CreateObligationStmtVisitorTest {
     void testSuccess() throws PMException {
         PMLParser.StatementContext ctx = TestPMLParser.parseStatement(
                 """
-                create obligation "test" {}
+                obligation "test" {}
                 """);
         VisitorContext visitorCtx = new VisitorContext(new CompileScope());
         PMLStatement<?> stmt = new CreateObligationStmtVisitor(visitorCtx).visit(ctx);
@@ -38,7 +38,7 @@ class CreateObligationStmtVisitorTest {
 
         testCompilationError(
                 """
-                create obligation ["test"] {}
+                obligation ["test"] {}
                 """, visitorCtx, 1,
                 "expected expression type string, got []string"
                 );

--- a/src/test/java/gov/nist/csd/pm/core/pap/pml/compiler/visitor/CreatePolicyStmtVisitorTest.java
+++ b/src/test/java/gov/nist/csd/pm/core/pap/pml/compiler/visitor/CreatePolicyStmtVisitorTest.java
@@ -19,7 +19,7 @@ class CreatePolicyStmtVisitorTest {
     void testSuccess() throws PMException {
         PMLParser.StatementContext ctx = TestPMLParser.parseStatement(
                 """
-                create policy class "test"
+                create PC "test"
                 """);
         VisitorContext visitorCtx = new VisitorContext(new CompileScope());
         PMLStatement stmt = new CreatePolicyStmtVisitor(visitorCtx).visit(ctx);
@@ -35,7 +35,7 @@ class CreatePolicyStmtVisitorTest {
     void testSuccessWithProperties() throws PMException {
         PMLParser.StatementContext ctx = TestPMLParser.parseStatement(
                 """
-                create policy class "test" 
+                create PC "test" 
                 """);
         VisitorContext visitorCtx = new VisitorContext(new CompileScope());
         PMLStatement stmt = new CreatePolicyStmtVisitor(visitorCtx).visit(ctx);
@@ -52,7 +52,7 @@ class CreatePolicyStmtVisitorTest {
 
         testCompilationError(
                 """
-                create policy class ["test"]
+                create PC ["test"]
                 """, visitorCtx, 1,
                 "expected expression type string, got []string"
         );

--- a/src/test/java/gov/nist/csd/pm/core/pap/pml/compiler/visitor/CreateProhibitionStmtVisitorTest.java
+++ b/src/test/java/gov/nist/csd/pm/core/pap/pml/compiler/visitor/CreateProhibitionStmtVisitorTest.java
@@ -28,7 +28,7 @@ class CreateProhibitionStmtVisitorTest {
         PMLParser.StatementContext ctx = TestPMLParser.parseStatement(
                 """
                 create prohibition "test"
-                deny user "u1"
+                deny u "u1"
                 access rights ["read"]
                 on union of {"oa1": true}
                 """);
@@ -57,7 +57,7 @@ class CreateProhibitionStmtVisitorTest {
         testCompilationError(
                 """
                 create prohibition ["test"]
-                deny user "u1"
+                deny u "u1"
                 access rights ["read"]
                 on union of {"oa1": true}
                 """, visitorCtx, 1,
@@ -67,7 +67,7 @@ class CreateProhibitionStmtVisitorTest {
         testCompilationError(
                 """
                 create prohibition "test"
-                deny user ["u1"]
+                deny u ["u1"]
                 access rights ["read"]
                 on union of {"oa1": true}
                 """, visitorCtx, 1,
@@ -77,7 +77,7 @@ class CreateProhibitionStmtVisitorTest {
         testCompilationError(
                 """
                 create prohibition "test"
-                deny user "u1"
+                deny u "u1"
                 access rights "read"
                 on union of {"oa1": true}
                 """, visitorCtx, 1,
@@ -87,7 +87,7 @@ class CreateProhibitionStmtVisitorTest {
         testCompilationError(
                 """
                 create prohibition "test"
-                deny user "u1"
+                deny u "u1"
                 access rights ["read"]
                 on union of "oa1"
                 """, visitorCtx, 1,

--- a/src/test/java/gov/nist/csd/pm/core/pap/pml/compiler/visitor/CreateRuleStmtVisitorTest.java
+++ b/src/test/java/gov/nist/csd/pm/core/pap/pml/compiler/visitor/CreateRuleStmtVisitorTest.java
@@ -28,18 +28,18 @@ class CreateRuleStmtVisitorTest {
     @Test
     void testSubjectClause() throws PMException {
         String pml = """
-                    create obligation "obligation1" {
-                        create rule "any user"
+                    obligation "obligation1" {
+                        rule "any user"
                         when any user
                         performs "test_event"
                         do(ctx) {}
                         
-                        create rule "users"
+                        rule "users"
                         when user "u1"
                         performs "test_event"
                         do(ctx) {}
                         
-                        create rule "users list"
+                        rule "users list"
                         when user "u1" || "u2"
                         performs "test_event"
                         do(ctx) {}
@@ -84,8 +84,8 @@ class CreateRuleStmtVisitorTest {
     @Test
     void testPerformsClause() throws PMException {
         String pml = """
-                    create obligation "obligation1" {
-                        create rule "r1"
+                    obligation "obligation1" {
+                        rule "r1"
                         when any user
                         performs any operation
                         do(ctx) {}
@@ -110,8 +110,8 @@ class CreateRuleStmtVisitorTest {
         assertEquals(expected, stmt);
 
         String pml2 = """
-            create obligation "obligation1" {
-                create rule "r1"
+            obligation "obligation1" {
+                rule "r1"
                 when any user
                 do(ctx) {}
             }
@@ -127,19 +127,19 @@ class CreateRuleStmtVisitorTest {
     @Test
     void testOnClause() throws PMException {
         String pml = """
-                    create obligation "obligation1" {
-                        create rule "any arg"
+                    obligation "obligation1" {
+                        rule "any arg"
                         when any user
                         performs any operation
                         do(ctx) {}
                         
-                        create rule "any arg with on"
+                        rule "any arg with on"
                         when any user
                         performs any operation
                         on {}
                         do(ctx) {}
                         
-                        create rule "an arg"
+                        rule "an arg"
                         when any user
                         performs "assign"
                         on {
@@ -187,13 +187,13 @@ class CreateRuleStmtVisitorTest {
     @Test
     void testResponse() throws PMException {
         String pml = """
-                    create obligation "obligation1" {
-                        create rule "r1"
+                    obligation "obligation1" {
+                        rule "r1"
                         when any user
                         performs any operation
                         do(ctx) {
-                            create policy class "pc1"
-                            create policy class "pc2"
+                            create PC "pc1"
+                            create PC "pc2"
                         }
                     }
                     """;
@@ -222,8 +222,8 @@ class CreateRuleStmtVisitorTest {
     @Test
     void testFunctionInResponseOk() throws PMException {
         String pml = """
-                    create obligation "obligation1" {
-                        create rule "e1 and e2"
+                    obligation "obligation1" {
+                        rule "e1 and e2"
                         when any user
                         performs any operation
                         do(ctx) {
@@ -237,8 +237,8 @@ class CreateRuleStmtVisitorTest {
     @Test
     void testReturnValueInResponseThrowsException() {
         String pml = """
-                    create obligation "obligation1" {
-                        create rule "any user"
+                    obligation "obligation1" {
+                        rule "any user"
                         when subject => pAny()
                         performs op => pEquals(op, "test_event")
                         do(ctx) {

--- a/src/test/java/gov/nist/csd/pm/core/pap/pml/compiler/visitor/IfStmtVisitorTest.java
+++ b/src/test/java/gov/nist/csd/pm/core/pap/pml/compiler/visitor/IfStmtVisitorTest.java
@@ -75,7 +75,7 @@ class IfStmtVisitorTest {
                         return
                     }
                     
-                    create policy class "pc1"
+                    create PC "pc1"
                 }
                 
                 f1()

--- a/src/test/java/gov/nist/csd/pm/core/pap/pml/expression/FunctionInvokeExpressionTest.java
+++ b/src/test/java/gov/nist/csd/pm/core/pap/pml/expression/FunctionInvokeExpressionTest.java
@@ -186,8 +186,8 @@ class FunctionInvokeExpressionTest {
                 }
                                 
                 operation b(string x, string y) {
-                    create policy class c(x)
-                    create policy class c(y)
+                    create PC c(x)
+                    create PC c(y)
                 }
                                 
                 operation a(string x) {

--- a/src/test/java/gov/nist/csd/pm/core/pap/pml/expression/reference/ReferenceByBracketIndexTest.java
+++ b/src/test/java/gov/nist/csd/pm/core/pap/pml/expression/reference/ReferenceByBracketIndexTest.java
@@ -72,7 +72,7 @@ class ReferenceByBracketIndexTest {
                     }
                 }
                 
-                create policy class a["b"]["c"]["d"]
+                create PC a["b"]["c"]["d"]
                 """;
         PAP pap = new TestPAP();
         pap.executePML(new UserContext(0), pml);
@@ -91,7 +91,7 @@ class ReferenceByBracketIndexTest {
                     }
                 }
                 
-                create policy class a[true]["c"]["d"]
+                create PC a[true]["c"]["d"]
                 """;
         PAP pap = new TestPAP();
         PMLCompilationException e = assertThrows(PMLCompilationException.class,
@@ -110,7 +110,7 @@ class ReferenceByBracketIndexTest {
                     }
                 }
                 
-                create policy class a["z"]["c"]["d"]
+                create PC a["z"]["c"]["d"]
                 """;
         PAP pap = new TestPAP();
         assertThrows(NullPointerException.class,
@@ -124,7 +124,7 @@ class ReferenceByBracketIndexTest {
                     ["a"]: "test"
                 }
                 
-                create policy class a[["a"]]
+                create PC a[["a"]]
                 """;
         PAP pap = new TestPAP();
         pap.executePML(new UserContext(0), pml);

--- a/src/test/java/gov/nist/csd/pm/core/pap/pml/expression/reference/ReferenceByDotIndexTest.java
+++ b/src/test/java/gov/nist/csd/pm/core/pap/pml/expression/reference/ReferenceByDotIndexTest.java
@@ -11,8 +11,10 @@ import gov.nist.csd.pm.core.pap.pml.context.ExecutionContext;
 import gov.nist.csd.pm.core.pap.pml.context.VisitorContext;
 import gov.nist.csd.pm.core.pap.pml.scope.CompileScope;
 
+import gov.nist.csd.pm.core.pap.pml.scope.VariableAlreadyDefinedInScopeException;
 import gov.nist.csd.pm.core.pap.query.model.context.UserContext;
 import gov.nist.csd.pm.core.util.TestPAP;
+import gov.nist.csd.pm.core.util.TestUserContext;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -21,6 +23,7 @@ import java.util.Map;
 import static gov.nist.csd.pm.core.pap.function.arg.type.Type.STRING_TYPE;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ReferenceByDotIndexTest {
@@ -71,7 +74,7 @@ class ReferenceByDotIndexTest {
                     }
                 }
                 
-                create policy class a.b.c.d
+                create PC a.b.c.d
                 """;
         PAP pap = new TestPAP();
         long pc1 = pap.modify().graph().createPolicyClass("pc1");
@@ -82,5 +85,28 @@ class ReferenceByDotIndexTest {
         assertTrue(pap.query().graph().nodeExists("e"));
     }
 
+    @Test
+    void testKeywordIndex() throws PMException {
+        String pml = """
+                operation test(map[string]string m) {
+                    create pc m.oa
+                }
+                
+                test({"oa": "test"})
+                """;
+        PAP pap = new TestPAP();
+        pap.executePML(new TestUserContext("u1"), pml);
+        assertTrue(pap.query().graph().nodeExists("test"));
+
+        String pml2 = """
+                operation test(map[string]string m) {
+                    create pc m.policy class
+                }
+                
+                test({"policy class": "test"})
+                """;
+        PAP pap2 = new TestPAP();
+        assertThrows(PMException.class, () -> pap2.executePML(new TestUserContext("u1"), pml2));
+    }
 
 }

--- a/src/test/java/gov/nist/csd/pm/core/pap/pml/pattern/OperationPatternTest.java
+++ b/src/test/java/gov/nist/csd/pm/core/pap/pml/pattern/OperationPatternTest.java
@@ -23,8 +23,8 @@ class OperationPatternTest {
     @Test
     void testPML() throws PMException {
         String pml = """
-                create obligation "ob1" {
-                    create rule "r1"
+                obligation "ob1" {
+                    rule "r1"
                     when any user
                     performs any operation
                     do(ctx) { }
@@ -34,8 +34,8 @@ class OperationPatternTest {
         assertEquals(new OperationPattern(), stmt.getOperationPattern());
 
         pml = """
-                create obligation "ob1" {
-                    create rule "r1"
+                obligation "ob1" {
+                    rule "r1"
                     when any user
                     performs "op1"
                     do(ctx) { }

--- a/src/test/java/gov/nist/csd/pm/core/pap/pml/pattern/arg/ArgPatternTest.java
+++ b/src/test/java/gov/nist/csd/pm/core/pap/pml/pattern/arg/ArgPatternTest.java
@@ -30,8 +30,8 @@ public class ArgPatternTest {
         pap.modify().graph().createObject("o2", List.of(oa2));
 
         String pml = """
-                create obligation "ob1" {
-                    create rule "r1"
+                obligation "ob1" {
+                    rule "r1"
                     when user "u1"
                     performs "assign"
                     on {
@@ -53,8 +53,8 @@ public class ArgPatternTest {
         assertTrue(stmt.getArgPattern().get("descendants").getFirst().matches("oa1", pap));
 
         pml = """
-                create obligation "ob1" {
-                    create rule "r1"
+                obligation "ob1" {
+                    rule "r1"
                     when user "u1"
                     performs "assign"
                     on {
@@ -76,8 +76,8 @@ public class ArgPatternTest {
         assertTrue(stmt.getArgPattern().get("descendants").getFirst().matches("oa1", pap));
 
         pml = """
-                create obligation "ob1" {
-                    create rule "r1"
+                obligation "ob1" {
+                    rule "r1"
                     when user "u1"
                     performs "assign"
                     on {
@@ -103,8 +103,8 @@ public class ArgPatternTest {
         assertTrue(stmt.getArgPattern().get("descendants").getFirst().matches("oa2", pap));
 
         pml = """
-                create obligation "ob1" {
-                    create rule "r1"
+                obligation "ob1" {
+                    rule "r1"
                     when user "u1"
                     performs "assign"
                     on {
@@ -148,8 +148,8 @@ public class ArgPatternTest {
         long u1 = pap.modify().graph().createUser("u1", List.of(ua1));
         assertThrows(NodeDoesNotExistException.class, () -> pap.executePML(new UserContext(u1), """
                 associate "ua1" and PM_ADMIN_BASE_OA with ["*a"]
-                create obligation "ob1" {
-                    create rule "r1"
+                obligation "ob1" {
+                    rule "r1"
                     when user "u1"
                     performs "create_object_attribute"
                     on {

--- a/src/test/java/gov/nist/csd/pm/core/pap/pml/pattern/subject/SubjectPatternTest.java
+++ b/src/test/java/gov/nist/csd/pm/core/pap/pml/pattern/subject/SubjectPatternTest.java
@@ -34,8 +34,8 @@ class SubjectPatternTest {
         pap.modify().graph().createUser("u2", List.of(ua2));
 
         String pml = """
-                create obligation "ob1" {
-                    create rule "r1"
+                obligation "ob1" {
+                    rule "r1"
                     when any user
                     performs any operation
                     do(ctx) { }
@@ -46,8 +46,8 @@ class SubjectPatternTest {
         assertTrue(stmt.getSubjectPattern().matches("u1", pap));
 
         pml = """
-                create obligation "ob1" {
-                    create rule "r1"
+                obligation "ob1" {
+                    rule "r1"
                     when user "u1"
                     performs any operation
                     do(ctx) { }
@@ -58,8 +58,8 @@ class SubjectPatternTest {
         assertTrue(stmt.getSubjectPattern().matches("u1", pap));
 
         pml = """
-                create obligation "ob1" {
-                    create rule "r1"
+                obligation "ob1" {
+                    rule "r1"
                     when user "u1" || "u2"
                     performs any operation
                     do(ctx) { }
@@ -74,8 +74,8 @@ class SubjectPatternTest {
         assertTrue(stmt.getSubjectPattern().matches("u1", pap));
 
         pml = """
-                create obligation "ob1" {
-                    create rule "r1"
+                obligation "ob1" {
+                    rule "r1"
                     when user "u1" && in "ua2"
                     performs any operation
                     do(ctx) { }
@@ -91,8 +91,8 @@ class SubjectPatternTest {
         assertFalse(stmt.getSubjectPattern().matches("u2", pap));
 
         pml = """
-                create obligation "ob1" {
-                    create rule "r1"
+                obligation "ob1" {
+                    rule "r1"
                     when user !in "ua1"
                     performs any operation
                     do(ctx) { }
@@ -106,8 +106,8 @@ class SubjectPatternTest {
         assertTrue(stmt.getSubjectPattern().matches("u2", pap));
 
         pml = """
-                create obligation "ob1" {
-                    create rule "r1"
+                obligation "ob1" {
+                    rule "r1"
                     when user ("u1" && in "ua2") || "u2"
                     performs any operation
                     do(ctx) { }
@@ -129,8 +129,8 @@ class SubjectPatternTest {
         assertTrue(stmt.getSubjectPattern().matches("u2", pap));
 
         pml = """
-                create obligation "ob1" {
-                    create rule "r1"
+                obligation "ob1" {
+                    rule "r1"
                     when user process "p1"
                     performs any operation
                     do(ctx) { }

--- a/src/test/java/gov/nist/csd/pm/core/pap/pml/statement/BreakStatementTest.java
+++ b/src/test/java/gov/nist/csd/pm/core/pap/pml/statement/BreakStatementTest.java
@@ -18,7 +18,7 @@ class BreakStatementTest {
     void testSuccess() throws PMException {
         String pml = """
                 foreach x in ["a", "b", "c"] {
-                    create policy class x
+                    create PC x
                     
                     if x == "b" {
                         break
@@ -37,7 +37,7 @@ class BreakStatementTest {
     void testMultipleLevels() throws PMException {
         String pml = """
                 foreach x in ["a", "b", "c"] {
-                    create policy class x
+                    create PC x
                     
                     if x == "b" {
                         if x == "b" {

--- a/src/test/java/gov/nist/csd/pm/core/pap/pml/statement/ContinueStatementTest.java
+++ b/src/test/java/gov/nist/csd/pm/core/pap/pml/statement/ContinueStatementTest.java
@@ -22,7 +22,7 @@ class ContinueStatementTest {
                         continue
                     }         
                     
-                    create policy class x         
+                    create PC x         
                 }
                 """;
         PAP pap = new TestPAP();
@@ -43,7 +43,7 @@ class ContinueStatementTest {
                         }   
                     }         
                     
-                    create policy class x         
+                    create PC x         
                 }
                 """;
         PAP pap = new TestPAP();

--- a/src/test/java/gov/nist/csd/pm/core/pap/pml/statement/FunctionDefinitionStatementTest.java
+++ b/src/test/java/gov/nist/csd/pm/core/pap/pml/statement/FunctionDefinitionStatementTest.java
@@ -147,8 +147,8 @@ class FunctionDefinitionStatementTest {
                 func1(a, b)
                 
                 operation func1(string a, string b) {
-                    create policy class a
-                    create policy class b
+                    create PC a
+                    create PC b
                 }
                 """;
         PAP pap = new TestPAP();
@@ -162,7 +162,7 @@ class FunctionDefinitionStatementTest {
     void testInvokeFromDefinition() throws PMException {
         String pml = """
                 operation f1(string a) {
-                    create policy class a
+                    create PC a
                 }
                 
                 operation f2() {
@@ -184,7 +184,7 @@ class FunctionDefinitionStatementTest {
                 x := "x"
                 
                 operation func2() {
-                    create policy class x
+                    create PC x
                 }
                 """;
         PAP pap = new TestPAP();

--- a/src/test/java/gov/nist/csd/pm/core/pap/pml/statement/IfStatementTest.java
+++ b/src/test/java/gov/nist/csd/pm/core/pap/pml/statement/IfStatementTest.java
@@ -23,16 +23,16 @@ class IfStatementTest {
         String pml = """
                 operation func1(string s) {
                     if s == "a" {
-                        create policy class s
+                        create PC s
 
                     } else if s == "b" {
-                        create policy class s
+                        create PC s
                     
                     } else if s == "c" {
-                        create policy class s
+                        create PC s
                     
                     } else {
-                        create policy class s
+                        create PC s
                     
                     }
                 }

--- a/src/test/java/gov/nist/csd/pm/core/pap/pml/statement/ReturnStatementTest.java
+++ b/src/test/java/gov/nist/csd/pm/core/pap/pml/statement/ReturnStatementTest.java
@@ -20,7 +20,7 @@ class ReturnStatementTest {
                     return "test"
                 }
                 
-                create policy class f1()
+                create PC f1()
                 """;
         PAP pap = new TestPAP();
         pap.executePML(new UserContext(0), pml);

--- a/src/test/java/gov/nist/csd/pm/core/pap/pml/statement/operation/CheckStatementTest.java
+++ b/src/test/java/gov/nist/csd/pm/core/pap/pml/statement/operation/CheckStatementTest.java
@@ -90,7 +90,7 @@ class CheckStatementTest {
                 operation op1() {
                     check "assign" on [testOp()]
                 } {
-                    create policy class "pc2"
+                    create PC "pc2"
                 }
                 
                 create pc "pc1"

--- a/src/test/java/gov/nist/csd/pm/core/pap/pml/statement/operation/CreateObligationStatementTest.java
+++ b/src/test/java/gov/nist/csd/pm/core/pap/pml/statement/operation/CreateObligationStatementTest.java
@@ -116,8 +116,8 @@ class CreateObligationStatementTest {
         );
         assertEquals(
                 """
-                        create obligation "obl1" {
-                            create rule "rule1"
+                        obligation "obl1" {
+                            rule "rule1"
                             when any user
                             performs "e1"
                             on {
@@ -127,7 +127,7 @@ class CreateObligationStatementTest {
                                 create PC "pc2"
                             }
                             
-                            create rule "rule2"
+                            rule "rule2"
                             when user "u1"
                             performs "e3"
                             on {

--- a/src/test/java/gov/nist/csd/pm/core/pap/pml/statement/operation/CreateRuleStatementTest.java
+++ b/src/test/java/gov/nist/csd/pm/core/pap/pml/statement/operation/CreateRuleStatementTest.java
@@ -30,7 +30,7 @@ class CreateRuleStatementTest {
 
         String actual = createRuleStatement.toFormattedString(0);
         assertTrue(actual.equals("""
-                create rule "rule1"
+                rule "rule1"
                 when any user
                 performs any operation
                 on {
@@ -39,7 +39,7 @@ class CreateRuleStatementTest {
                 }
                 do () {
                 }""".trim()) || actual.equals("""
-                create rule "rule1"
+                rule "rule1"
                 when any user
                 performs any operation
                 on {

--- a/src/test/java/gov/nist/csd/pm/core/pap/pml/statement/operation/OperationDefinitionStatementTest.java
+++ b/src/test/java/gov/nist/csd/pm/core/pap/pml/statement/operation/OperationDefinitionStatementTest.java
@@ -35,7 +35,7 @@ class OperationDefinitionStatementTest {
                     check "assign" on b
                     check "assign" on ["oa1"]
                 } {
-                    create policy class "test"
+                    create PC "test"
                 }
                 """;
         MemoryPAP pap = new TestPAP();
@@ -74,7 +74,7 @@ class OperationDefinitionStatementTest {
                 create o "o3" in ["oa1"]
                 
                 operation op1(string a, []string b) {
-                    create policy class a
+                    create PC a
                 }
                 """;
         MemoryPAP pap = new TestPAP();

--- a/src/test/java/gov/nist/csd/pm/core/pap/query/AccessQuerierTest.java
+++ b/src/test/java/gov/nist/csd/pm/core/pap/query/AccessQuerierTest.java
@@ -150,7 +150,7 @@ public abstract class AccessQuerierTest extends PAPTestInitializer {
                 create o "o2" in ["oa4"]
                 
                 create prohibition "p1"
-                deny user "u1"
+                deny u "u1"
                 access rights ["write"]
                 on union of {"oa1": false}
                 """;
@@ -185,12 +185,12 @@ public abstract class AccessQuerierTest extends PAPTestInitializer {
                 create o "o1" in ["oa1", "oa3"]
                 
                 create prohibition "p1"
-                deny user "u1" 
+                deny u "u1" 
                 access rights ["write"]
                 on union of {"oa1": false}
                 
                 create prohibition "p2"
-                deny user "u1" 
+                deny u "u1" 
                 access rights ["write"]
                 on union of {"oa1": true}
                 """;
@@ -296,8 +296,8 @@ public abstract class AccessQuerierTest extends PAPTestInitializer {
                 create oa "oa4" in ["pc2"]
                 associate "ua4" and "oa4" with ["read"]
                 
-                create user "u1" in ["ua2", "ua3", "ua4"]
-                create object "o1" in ["oa2", "oa3", "oa4"]
+                create U "u1" in ["ua2", "ua3", "ua4"]
+                create O "o1" in ["oa2", "oa3", "oa4"]
                 """;
         pap.executePML(new UserContext(0), pml);
 
@@ -397,7 +397,7 @@ public abstract class AccessQuerierTest extends PAPTestInitializer {
                     associate "ua1" and "oa1" with ["write"]
                     associate "ua1" and "oa2" with ["read"]
                
-                create user "u1" in ["ua1"]
+                create U "u1" in ["ua1"]
                 """;
         pap.executePML(new TestUserContext("u1"), pml);
         Explain actual = pap.query().access().explain(new UserContext(id("u1")), new TargetContext(id("oa2")));
@@ -440,8 +440,8 @@ public abstract class AccessQuerierTest extends PAPTestInitializer {
 
                     associate "ua1" and "oa1" with ["write"]
                
-                create user "u1" in ["ua2"]
-                create object "o1" in ["oa1"]
+                create U "u1" in ["ua2"]
+                create O "o1" in ["oa1"]
                 """;
         pap.executePML(new TestUserContext("u1"), pml);
         Explain actual = pap.query().access().explain(new UserContext(id("u1")), new TargetContext(id("o1")));
@@ -486,8 +486,8 @@ public abstract class AccessQuerierTest extends PAPTestInitializer {
                     
                     associate "ua2" and "oa2" with ["read"]
                
-                create user "u1" in ["ua1", "ua2"]
-                create object "o1" in ["oa1", "oa2"]
+                create U "u1" in ["ua1", "ua2"]
+                create O "o1" in ["oa1", "oa2"]
                 """;
         pap.executePML(new TestUserContext("u1"), pml);
         Explain actual = pap.query().access().explain(new UserContext(id("u1")), new TargetContext(id("o1")));
@@ -546,8 +546,8 @@ public abstract class AccessQuerierTest extends PAPTestInitializer {
                     
                     associate "ua2" and "oa2" with ["read", "write"]
                
-                create user "u1" in ["ua1", "ua2"]
-                create object "o1" in ["oa1", "oa2"]
+                create U "u1" in ["ua1", "ua2"]
+                create O "o1" in ["oa1", "oa2"]
                 """;
         pap.executePML(new TestUserContext("u1"), pml);
         Explain actual = pap.query().access().explain(new UserContext(id("u1")), new TargetContext(id("o1")));
@@ -603,8 +603,8 @@ public abstract class AccessQuerierTest extends PAPTestInitializer {
                     
                     associate "ua2" and "oa2" with ["read"]
                
-                create user "u1" in ["ua1", "ua2"]
-                create object "o1" in ["oa1", "oa2"]
+                create U "u1" in ["ua1", "ua2"]
+                create O "o1" in ["oa1", "oa2"]
                 """;
         pap.reset();
         pap.executePML(new TestUserContext("u1"), pml);
@@ -665,7 +665,7 @@ public abstract class AccessQuerierTest extends PAPTestInitializer {
                 create o "o2" in ["oa2"]
                 
                 create prohibition "p1"
-                deny user "u1"
+                deny u "u1"
                 access rights ["write"]
                 on union of {"o1": false}
                 """;
@@ -766,7 +766,7 @@ public abstract class AccessQuerierTest extends PAPTestInitializer {
                 create o "o2" in ["oa2"]
                 
                 create prohibition "p1"
-                deny user "u1" 
+                deny u "u1" 
                 access rights ["write"]
                 on union of {"oa1": false}
                 """;
@@ -814,7 +814,7 @@ public abstract class AccessQuerierTest extends PAPTestInitializer {
                 create o "o1" in ["oa1"]
                 
                 create prohibition "p1"
-                deny user "u1" 
+                deny u "u1" 
                 access rights ["write"]
                 on union of {"oa1": false}
                 """;
@@ -1628,7 +1628,7 @@ public abstract class AccessQuerierTest extends PAPTestInitializer {
         // create a prohibition for the user on the object
         pml = """
                 create prohibition "p1"
-                deny user "u1"
+                deny u "u1"
                 access rights ["read"]
                 on union of {"o1": false}
                 """;
@@ -1650,7 +1650,7 @@ public abstract class AccessQuerierTest extends PAPTestInitializer {
                 delete prohibition "p1"
                 
                 create prohibition "p1"
-                deny user "u1"
+                deny u "u1"
                 access rights ["read"]
                 on intersection of {"oa1": false, "oa2": false}
                 """;

--- a/src/test/java/gov/nist/csd/pm/core/pdp/PDPTest.java
+++ b/src/test/java/gov/nist/csd/pm/core/pdp/PDPTest.java
@@ -265,7 +265,7 @@ class PDPTest {
         });
         pap.executePML(new TestUserContext("u1"), """
                 routine routine2() map[string]string {
-                    create policy class "test2"
+                    create PC "test2"
                     return {"test2": "test2"}
                 }
                 """);
@@ -363,8 +363,8 @@ class PDPTest {
                     }
                 }
                 
-                create obligation "o1" {
-                    create rule "r1"
+                obligation "o1" {
+                    rule "r1"
                     when any user
                     performs "create_user_attribute"
                     do(ctx) {
@@ -398,8 +398,8 @@ class PDPTest {
                     create pc name
                 }
                 
-                create obligation "obl1" {
-                    create rule "rule1"
+                obligation "obl1" {
+                    rule "rule1"
                     when any user
                     performs "op1"
                     do(ctx) {

--- a/src/test/java/gov/nist/csd/pm/core/pdp/adjudicator/PrivilegeCheckerTest.java
+++ b/src/test/java/gov/nist/csd/pm/core/pdp/adjudicator/PrivilegeCheckerTest.java
@@ -27,7 +27,7 @@ class PrivilegeCheckerTest {
                 """
                         set resource operations ["read", "write"]
                         
-                        create policy class "pc1"
+                        create PC "pc1"
                             create ua "ua1" in ["pc1"]
                             create ua "ua2" in ["pc1"]
 
@@ -37,10 +37,10 @@ class PrivilegeCheckerTest {
                             associate "ua1" and "oa1" with ["read", "write"]
                             associate "ua1" and PM_ADMIN_BASE_OA with ["read"]
                       
-                        create user "u1" in ["ua1"]
-                        create user "u2" in ["ua2"]
+                        create U "u1" in ["ua1"]
+                        create U "u2" in ["ua2"]
                         
-                        create object "o1" in ["oa1"]
+                        create O "o1" in ["oa1"]
                         """
         );
     }

--- a/src/test/resources/sample/sample.json
+++ b/src/test/resources/sample/sample.json
@@ -195,7 +195,7 @@
     {
       "author": 14,
       "name": "create us project admin",
-      "pml": "create obligation \"create us project admin\" {\n    create rule \"us project\"\n    when any user\n    performs \"createProject\"\n    on {\n        locProjectAttr: \"US project\"\n    }\n    do (ctx) {\n        createProjectAdmin(ctx.args.projectName)\n    }\n\n    create rule \"eu project\"\n    when any user\n    performs \"createProject\"\n    on {\n        locProjectAttr: \"EU project\"\n    }\n    do (ctx) {\n        createProjectAdmin(ctx.args.projectName)\n    }\n\n}"
+      "pml": "obligation \"create us project admin\" {\n    rule \"us project\"\n    when any user\n    performs \"createProject\"\n    on {\n        locProjectAttr: \"US project\"\n    }\n    do (ctx) {\n        createProjectAdmin(ctx.args.projectName)\n    }\n\n    rule \"eu project\"\n    when any user\n    performs \"createProject\"\n    on {\n        locProjectAttr: \"EU project\"\n    }\n    do (ctx) {\n        createProjectAdmin(ctx.args.projectName)\n    }\n\n}"
     }
   ],
   "operations": [

--- a/src/test/resources/sample/sample.pml
+++ b/src/test/resources/sample/sample.pml
@@ -24,11 +24,11 @@ create pc "Location"
     associate "US user" and "US project" with ["*"]
     associate "EU user" and "EU project" with ["*"]
 
-create user "us_reader1" in ["reader", "US user"]
-create user "us_writer1" in ["writer", "US user"]
+create U "us_reader1" in ["reader", "US user"]
+create U "us_writer1" in ["writer", "US user"]
 
-create user "eu_reader1" in ["reader", "EU user"]
-create user "eu_writer1" in ["writer", "EU user"]
+create U "eu_reader1" in ["reader", "EU user"]
+create U "eu_writer1" in ["writer", "EU user"]
 
 createProject("us_project1", "US project")
 createProject("eu_project1", "EU project")
@@ -66,13 +66,13 @@ operation createProjectAdmin(string projectName) {
     associate uaName and projectName with ["*"]
 
     create prohibition "deny admin delete README"
-    deny user attribute uaName
+    deny UA uaName
     access rights ["delete_readme"]
     on union of {projectName: false}
 }
 
-create obligation "create us project admin" {
-    create rule "us project"
+obligation "create us project admin" {
+    rule "us project"
     when any user
     performs "createProject"
     on {
@@ -82,7 +82,7 @@ create obligation "create us project admin" {
         createProjectAdmin(ctx.args.projectName)
     }
 
-    create rule "eu project"
+    rule "eu project"
     when any user
     performs "createProject"
     on {


### PR DESCRIPTION
- fixes process value in event context
- removes "create" from obligation and rule statements
- allows keywords as indexes for maps
  - previously, to access the event context "process" or "user" fields, you had to use brackets `ctx["user"]`, now you can just call `ctx.user`