### PR TITLE
add "if exists" to delete statement in PML

### DIFF
--- a/src/main/java/gov/nist/csd/pm/core/pap/pml/antlr4/PMLLexer.g4
+++ b/src/main/java/gov/nist/csd/pm/core/pap/pml/antlr4/PMLLexer.g4
@@ -10,8 +10,9 @@ CHECK: 'check';
 ROUTINE: 'routine';
 FUNCTION: 'function';
 
-CREATE      : 'create' ;
-DELETE      : 'delete' ;
+CREATE : 'create' ;
+DELETE : 'delete' ;
+IF_EXISTS : 'if exists';
 
 // obligation keywords
 RULE: 'rule' ;

--- a/src/main/java/gov/nist/csd/pm/core/pap/pml/antlr4/PMLParser.g4
+++ b/src/main/java/gov/nist/csd/pm/core/pap/pml/antlr4/PMLParser.g4
@@ -143,7 +143,7 @@ setResourceOperationsStatement:
     SET_RESOURCE_OPERATIONS accessRightsArr=expression;
 
 deleteStatement:
-    DELETE deleteType expression ;
+    DELETE (IF_EXISTS)? deleteType expression ;
 deleteType:
     NODE #DeleteNode
     | OBLIGATION #DeleteObligation

--- a/src/main/java/gov/nist/csd/pm/core/pap/pml/compiler/visitor/DeleteStmtVisitor.java
+++ b/src/main/java/gov/nist/csd/pm/core/pap/pml/compiler/visitor/DeleteStmtVisitor.java
@@ -20,15 +20,16 @@ public class DeleteStmtVisitor extends PMLBaseVisitor<DeleteStatement<?>> {
 
     @Override
     public DeleteStatement<?> visitDeleteStatement(PMLParser.DeleteStatementContext ctx) {
-        Expression nameExpr = ExpressionVisitor.compile(visitorCtx, ctx.expression(), STRING_TYPE);
+        Expression<String> nameExpr = ExpressionVisitor.compile(visitorCtx, ctx.expression(), STRING_TYPE);
+        boolean ifExists = ctx.IF_EXISTS() != null;
 
         PMLParser.DeleteTypeContext deleteTypeCtx = ctx.deleteType();
         if (deleteTypeCtx instanceof PMLParser.DeleteNodeContext) {
-           return new DeleteNodeStatement(nameExpr);
+           return new DeleteNodeStatement(nameExpr, ifExists);
         } else if (deleteTypeCtx instanceof PMLParser.DeleteProhibitionContext) {
-            return new DeleteProhibitionStatement(nameExpr);
+            return new DeleteProhibitionStatement(nameExpr, ifExists);
         } else {
-            return new DeleteObligationStatement(nameExpr);
+            return new DeleteObligationStatement(nameExpr, ifExists);
         }
     }
 }

--- a/src/main/java/gov/nist/csd/pm/core/pap/pml/statement/operation/DeleteNodeStatement.java
+++ b/src/main/java/gov/nist/csd/pm/core/pap/pml/statement/operation/DeleteNodeStatement.java
@@ -4,7 +4,6 @@ import gov.nist.csd.pm.core.common.exception.NodeDoesNotExistException;
 import gov.nist.csd.pm.core.common.exception.PMException;
 import gov.nist.csd.pm.core.common.graph.node.NodeType;
 import gov.nist.csd.pm.core.pap.PAP;
-import gov.nist.csd.pm.core.pap.function.arg.Args;
 import gov.nist.csd.pm.core.pap.function.op.graph.DeleteNodeOp;
 import gov.nist.csd.pm.core.pap.function.op.graph.DeleteNodeOp.DeleteNodeOpArgs;
 import gov.nist.csd.pm.core.pap.pml.context.ExecutionContext;
@@ -14,14 +13,14 @@ import it.unimi.dsi.fastutil.longs.LongArrayList;
 
 public class DeleteNodeStatement extends DeleteStatement<DeleteNodeOpArgs> {
 
-    public DeleteNodeStatement(Expression<String> expression) {
-        super(new DeleteNodeOp(), Type.NODE, expression);
+    public DeleteNodeStatement(Expression<String> expression, boolean ifExists) {
+        super(new DeleteNodeOp(), Type.NODE, expression, ifExists);
     }
 
     @Override
     public DeleteNodeOpArgs prepareArgs(ExecutionContext ctx, PAP pap) throws PMException {
         // prepare for execution by replacing the name arg with the ID arg
-        String name = expression.execute(ctx, pap);
+        String name = nameExpression.execute(ctx, pap);
 
         try {
             GraphQuery graph = pap.query().graph();
@@ -35,4 +34,9 @@ public class DeleteNodeStatement extends DeleteStatement<DeleteNodeOpArgs> {
             return new DeleteNodeOpArgs(0L, NodeType.U, new LongArrayList());
         }
     }
-} 
+
+    @Override
+    public boolean exists(PAP pap, String name) throws PMException {
+        return pap.query().graph().nodeExists(name);
+    }
+}

--- a/src/main/java/gov/nist/csd/pm/core/pap/pml/statement/operation/DeleteObligationStatement.java
+++ b/src/main/java/gov/nist/csd/pm/core/pap/pml/statement/operation/DeleteObligationStatement.java
@@ -11,16 +11,21 @@ import java.util.ArrayList;
 
 public class DeleteObligationStatement extends DeleteStatement<ObligationOpArgs> {
 
-    public DeleteObligationStatement(Expression<String> expression) {
-        super(new DeleteObligationOp(), Type.OBLIGATION, expression);
+    public DeleteObligationStatement(Expression<String> expression, boolean ifExists) {
+        super(new DeleteObligationOp(), Type.OBLIGATION, expression, ifExists);
     }
 
     @Override
     public ObligationOpArgs prepareArgs(ExecutionContext ctx, PAP pap) throws PMException {
-        String name = expression.execute(ctx, pap);
+        String name = nameExpression.execute(ctx, pap);
 
         Obligation obligation = pap.query().obligations().getObligation(name);
 
         return new ObligationOpArgs(obligation.getAuthorId(), obligation.getName(), new ArrayList<>(obligation.getRules()));
+    }
+
+    @Override
+    public boolean exists(PAP pap, String name) throws PMException {
+        return pap.query().obligations().obligationExists(name);
     }
 }

--- a/src/main/java/gov/nist/csd/pm/core/pap/pml/statement/operation/DeleteProhibitionStatement.java
+++ b/src/main/java/gov/nist/csd/pm/core/pap/pml/statement/operation/DeleteProhibitionStatement.java
@@ -3,7 +3,6 @@ package gov.nist.csd.pm.core.pap.pml.statement.operation;
 import gov.nist.csd.pm.core.common.exception.PMException;
 import gov.nist.csd.pm.core.common.prohibition.Prohibition;
 import gov.nist.csd.pm.core.pap.PAP;
-import gov.nist.csd.pm.core.pap.function.arg.Args;
 import gov.nist.csd.pm.core.pap.function.op.prohibition.DeleteProhibitionOp;
 import gov.nist.csd.pm.core.pap.function.op.prohibition.ProhibitionOp.ProhibitionOpArgs;
 import gov.nist.csd.pm.core.pap.pml.context.ExecutionContext;
@@ -12,13 +11,13 @@ import java.util.ArrayList;
 
 public class DeleteProhibitionStatement extends DeleteStatement<ProhibitionOpArgs> {
 
-    public DeleteProhibitionStatement(Expression<String> expression) {
-        super(new DeleteProhibitionOp(), Type.PROHIBITION, expression);
+    public DeleteProhibitionStatement(Expression<String> expression, boolean ifExists) {
+        super(new DeleteProhibitionOp(), Type.PROHIBITION, expression, ifExists);
     }
 
     @Override
     public ProhibitionOpArgs prepareArgs(ExecutionContext ctx, PAP pap) throws PMException {
-        String name = expression.execute(ctx, pap);
+        String name = nameExpression.execute(ctx, pap);
 
         Prohibition prohibition = pap.query().prohibitions().getProhibition(name);
 
@@ -27,5 +26,10 @@ public class DeleteProhibitionStatement extends DeleteStatement<ProhibitionOpArg
             prohibition.getAccessRightSet(),
             prohibition.isIntersection(),
             new ArrayList<>(prohibition.getContainers()));
+    }
+
+    @Override
+    public boolean exists(PAP pap, String name) throws PMException {
+        return pap.query().prohibitions().prohibitionExists(name);
     }
 }

--- a/src/main/java/gov/nist/csd/pm/core/pap/query/ProhibitionsQuerier.java
+++ b/src/main/java/gov/nist/csd/pm/core/pap/query/ProhibitionsQuerier.java
@@ -56,6 +56,11 @@ public class ProhibitionsQuerier extends Querier implements ProhibitionsQuery {
     }
 
     @Override
+    public boolean prohibitionExists(String name) throws PMException {
+        return store.prohibitions().prohibitionExists(name);
+    }
+
+    @Override
     public Collection<Prohibition> getInheritedProhibitionsFor(long subjectId) throws PMException {
         List<Prohibition> pros = new ArrayList<>();
 

--- a/src/main/java/gov/nist/csd/pm/core/pap/query/ProhibitionsQuery.java
+++ b/src/main/java/gov/nist/csd/pm/core/pap/query/ProhibitionsQuery.java
@@ -30,14 +30,25 @@ public interface ProhibitionsQuery {
 
     /**
      * Get the prohibition with the given name.
-     * @param name The public abstract of the prohibition to get.
-     * @return The prohibition with the given public abstract.
+     *
+     * @param name The name of the prohibition to get.
+     * @return The prohibition with the given name.
      * @throws PMException If any PM related exceptions occur in the implementing class.
      */
     Prohibition getProhibition(String name) throws PMException;
 
     /**
+     * Returns true if a prohibition with the provided name exists. Otherwise, false.
+     *
+     * @param name The name of the prohibition to check for.
+     * @return True if a prohibition with the provided name exists. Otherwise, false.
+     * @throws PMException If any PM related exceptions occur in the implementing class.
+     */
+    boolean prohibitionExists(String name) throws PMException;
+
+    /**
      * Get the prohibitions the given subject inherits through assignments.
+     *
      * @param subjectId The subject node.
      * @return The prohibitions the given subject inherits.
      * @throws PMException If any PM related exceptions occur in the implementing class.

--- a/src/test/java/gov/nist/csd/pm/core/pap/pml/compiler/visitor/DeleteStmtVisitorTest.java
+++ b/src/test/java/gov/nist/csd/pm/core/pap/pml/compiler/visitor/DeleteStmtVisitorTest.java
@@ -21,13 +21,13 @@ class DeleteStmtVisitorTest {
     void testDeleteNode() throws PMException {
         PMLParser.StatementContext ctx = TestPMLParser.parseStatement(
                 """
-                delete node "oa1"
+                delete if exists node "oa1"
                 """);
         VisitorContext visitorCtx = new VisitorContext(new CompileScope());
         PMLStatement stmt = new DeleteStmtVisitor(visitorCtx).visit(ctx);
         assertEquals(0, visitorCtx.errorLog().getErrors().size());
         assertEquals(
-                new DeleteNodeStatement(new StringLiteralExpression("oa1")),
+                new DeleteNodeStatement(new StringLiteralExpression("oa1"), true),
                 stmt
         );
     }
@@ -54,7 +54,7 @@ class DeleteStmtVisitorTest {
         PMLStatement stmt = new DeleteStmtVisitor(visitorCtx).visit(ctx);
         assertEquals(0, visitorCtx.errorLog().getErrors().size());
         assertEquals(
-                new DeleteObligationStatement(new StringLiteralExpression("test")),
+                new DeleteObligationStatement(new StringLiteralExpression("test"), false),
                 stmt
         );
     }
@@ -69,7 +69,7 @@ class DeleteStmtVisitorTest {
         PMLStatement stmt = new DeleteStmtVisitor(visitorCtx).visit(ctx);
         assertEquals(0, visitorCtx.errorLog().getErrors().size());
         assertEquals(
-                new DeleteProhibitionStatement(new StringLiteralExpression("test")),
+                new DeleteProhibitionStatement(new StringLiteralExpression("test"), false),
                 stmt
         );
     }

--- a/src/test/java/gov/nist/csd/pm/core/pap/pml/statement/operation/DeleteStatementTest.java
+++ b/src/test/java/gov/nist/csd/pm/core/pap/pml/statement/operation/DeleteStatementTest.java
@@ -30,9 +30,9 @@ class DeleteStatementTest {
 
     @Test
     void testSuccess() throws PMException {
-        DeleteStatement stmt1 = new DeleteNodeStatement(new StringLiteralExpression("oa1"));
-        DeleteStatement stmt2 = new DeleteProhibitionStatement(new StringLiteralExpression("p1"));
-        DeleteStatement stmt3 = new DeleteObligationStatement(new StringLiteralExpression("o1"));
+        DeleteStatement stmt1 = new DeleteNodeStatement(new StringLiteralExpression("oa1"), false);
+        DeleteStatement stmt2 = new DeleteProhibitionStatement(new StringLiteralExpression("p1"), false);
+        DeleteStatement stmt3 = new DeleteObligationStatement(new StringLiteralExpression("o1"), false);
 
         PAP pap = new TestPAP();
         pap.modify().operations().setResourceOperations(new AccessRightSet("read"));
@@ -63,14 +63,27 @@ class DeleteStatementTest {
     }
 
     @Test
+    void testSuccessIfExists() throws PMException {
+        DeleteStatement stmt1 = new DeleteNodeStatement(new StringLiteralExpression("oa1"), true);
+        DeleteStatement stmt2 = new DeleteProhibitionStatement(new StringLiteralExpression("p1"), true);
+        DeleteStatement stmt3 = new DeleteObligationStatement(new StringLiteralExpression("o1"), true);
+
+        PAP pap = new TestPAP();
+        TestUserContext testUserContext = new TestUserContext("u1");
+        assertDoesNotThrow(() -> stmt1.execute(new ExecutionContext(testUserContext, pap), pap));
+        assertDoesNotThrow(() -> stmt2.execute(new ExecutionContext(testUserContext, pap), pap));
+        assertDoesNotThrow(() -> stmt3.execute(new ExecutionContext(testUserContext, pap), pap));
+    }
+
+    @Test
     void testToFormattedString() {
-        DeleteStatement stmt = new DeleteNodeStatement(new StringLiteralExpression("test"));
-        DeleteStatement stmt1 = new DeleteProhibitionStatement(new StringLiteralExpression("test"));
-        DeleteStatement stmt2 = new DeleteObligationStatement( new StringLiteralExpression("test"));
-        DeleteStatement stmt3 = new DeleteNodeStatement(new StringLiteralExpression("test"));
-        DeleteStatement stmt4 = new DeleteNodeStatement(new StringLiteralExpression("test"));
-        DeleteStatement stmt5 = new DeleteNodeStatement(new StringLiteralExpression("test"));
-        DeleteStatement stmt6 = new DeleteNodeStatement(new StringLiteralExpression("test"));
+        DeleteStatement stmt = new DeleteNodeStatement(new StringLiteralExpression("test"), false);
+        DeleteStatement stmt1 = new DeleteProhibitionStatement(new StringLiteralExpression("test"), false);
+        DeleteStatement stmt2 = new DeleteObligationStatement( new StringLiteralExpression("test"), false);
+        DeleteStatement stmt3 = new DeleteNodeStatement(new StringLiteralExpression("test"), false);
+        DeleteStatement stmt4 = new DeleteNodeStatement(new StringLiteralExpression("test"), false);
+        DeleteStatement stmt5 = new DeleteNodeStatement(new StringLiteralExpression("test"), false);
+        DeleteStatement stmt6 = new DeleteNodeStatement(new StringLiteralExpression("test"), false);
 
         assertEquals("delete node \"test\"", stmt.toFormattedString(0));
         assertEquals("delete prohibition \"test\"", stmt1.toFormattedString(0));

--- a/src/test/java/gov/nist/csd/pm/core/pap/query/ProhibitionsQuerierTest.java
+++ b/src/test/java/gov/nist/csd/pm/core/pap/query/ProhibitionsQuerierTest.java
@@ -157,6 +157,20 @@ public abstract class ProhibitionsQuerierTest extends PAPTestInitializer {
     }
 
     @Test
+    void testProhibitionExists() throws PMException {
+        long pc1 = pap.modify().graph().createPolicyClass("pc1");
+        long subject = pap.modify().graph().createUserAttribute("subject", List.of(pc1));
+        long oa1 = pap.modify().graph().createObjectAttribute("oa1", List.of(pc1));
+        pap.modify().operations().setResourceOperations(new AccessRightSet("read", "write"));
+
+        pap.modify().prohibitions().createProhibition("label1", new ProhibitionSubject(subject), new AccessRightSet("read"),
+            true, List.of(new ContainerCondition(oa1, true)));
+
+        assertTrue(pap.query().prohibitions().prohibitionExists("label1"));
+        assertFalse(pap.query().prohibitions().prohibitionExists("label2"));
+    }
+
+    @Test
     void testGetInheritedProhibitionsFor() throws PMException, IOException {
         SamplePolicy.loadSamplePolicyFromPML(pap);
 


### PR DESCRIPTION
- adds an "if exists" clause to the PML delete statement. If the clause is present and the entity to be deleted does not exist, than no error will occur.