### PR TITLE
ignore plugins in bootstrapping

### DIFF
--- a/src/main/java/gov/nist/csd/pm/core/pap/PAP.java
+++ b/src/main/java/gov/nist/csd/pm/core/pap/PAP.java
@@ -220,11 +220,18 @@ public abstract class PAP implements AdminFunctionExecutor, Transactional {
         boolean obligationsEmpty = query().obligations().getObligations().isEmpty();
         boolean resOpsEmpty = query().operations().getResourceOperations().isEmpty();
 
-        boolean adminOpsEmpty =  query().operations().getAdminOperationNames().isEmpty();
-        boolean routinesEmpty = query().routines().getAdminRoutineNames().isEmpty();
-
         // ignore admin nodes
         nodes.removeIf(n -> AdminPolicyNode.isAdminPolicyNode(n.getId()));
+
+        // ignore plugin registry ops and routines
+        Collection<String> adminOperationNames = query().operations().getAdminOperationNames();
+        Collection<String> adminRoutineNames = query().routines().getAdminRoutineNames();
+
+        adminOperationNames.removeAll(pluginRegistry.getOperationNames());
+        adminRoutineNames.removeAll(pluginRegistry.getRoutineNames());
+
+        boolean adminOpsEmpty = adminOperationNames.isEmpty();
+        boolean routinesEmpty = adminRoutineNames.isEmpty();
 
         return nodes.isEmpty()
             && prohibitionsEmpty

--- a/src/main/java/gov/nist/csd/pm/core/pdp/bootstrap/PMLBootstrapper.java
+++ b/src/main/java/gov/nist/csd/pm/core/pdp/bootstrap/PMLBootstrapper.java
@@ -2,6 +2,7 @@ package gov.nist.csd.pm.core.pdp.bootstrap;
 
 import gov.nist.csd.pm.core.common.exception.PMException;
 import gov.nist.csd.pm.core.pap.PAP;
+import gov.nist.csd.pm.core.pap.function.PluginRegistry;
 import gov.nist.csd.pm.core.pap.function.op.Operation;
 import gov.nist.csd.pm.core.pap.function.routine.Routine;
 
@@ -11,35 +12,16 @@ import java.util.List;
 
 public class PMLBootstrapper extends PolicyBootstrapper {
 
-    private List<Operation<?, ?>> operations;
-    private List<Routine<?, ?>> routines;
     private final String bootstrapUser;
     private final String pml;
 
-    public PMLBootstrapper(List<Operation<?, ?>> operations, List<Routine<?, ?>> routines, String bootstrapUser, String pml) {
-        this.operations = operations;
-        this.routines = routines;
-        this.bootstrapUser = bootstrapUser;
-        this.pml = pml;
-    }
-
     public PMLBootstrapper(String bootstrapUser, String pml) {
-        this.operations = new ArrayList<>();
-        this.routines = new ArrayList<>();
         this.bootstrapUser = bootstrapUser;
         this.pml = pml;
     }
 
     @Override
     public void bootstrap(PAP pap) throws PMException {
-        for (Operation<?, ?> op : operations) {
-            pap.plugins().registerOperation(op);
-        }
-
-        for (Routine<?, ?> r : routines) {
-            pap.plugins().registerRoutine(r);
-        }
-
         pap.runTx(tx -> {
             // create bootstrap policy and user
             long pc = tx.modify().graph().createPolicyClass("bootstrap");

--- a/src/test/java/gov/nist/csd/pm/core/pap/pml/pattern/subject/SubjectPatternTest.java
+++ b/src/test/java/gov/nist/csd/pm/core/pap/pml/pattern/subject/SubjectPatternTest.java
@@ -167,7 +167,7 @@ class SubjectPatternTest {
                 }
                 """;
         MemoryPAP memoryPAP = new MemoryPAP();
-        memoryPAP.bootstrap(new PMLBootstrapper(List.of(), List.of(), "u2", pml));
+        memoryPAP.bootstrap(new PMLBootstrapper("u2", pml));
 
         PDP pdp = new PDP(memoryPAP);
         EPP epp = new EPP(pdp, memoryPAP);

--- a/src/test/java/gov/nist/csd/pm/core/pdp/PMLBootstrapperTest.java
+++ b/src/test/java/gov/nist/csd/pm/core/pdp/PMLBootstrapperTest.java
@@ -74,7 +74,10 @@ class PMLBootstrapperTest {
             }
         };
 
-        pdp.bootstrap(new PMLBootstrapper(List.of(op1), List.of(routine1), "u1", input));
+        pap.plugins().registerOperation(op1);
+        pap.plugins().registerRoutine(routine1);
+
+        pdp.bootstrap(new PMLBootstrapper("u1", input));
 
         assertTrue(pap.query().graph().nodeExists("pc1"));
         assertTrue(pap.query().graph().nodeExists("op1"));
@@ -90,7 +93,7 @@ class PMLBootstrapperTest {
         PDP pdp = new PDP(pap);
 
         assertThrows(DisconnectedNodeException.class, () -> pdp.bootstrap(new PMLBootstrapper(
-            List.of(), List.of(), "u1", "create pc \"pc1\""
+            "u1", "create pc \"pc1\""
         )));
     }
 


### PR DESCRIPTION
fixes issue where plugins were causing the bootstrap method in PAP to throw an exception.